### PR TITLE
Allow Imperative mismatch and update Imperative

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@types/node": "^16.11.1",
         "@zowe/cli": "^6.37.1",
-        "@zowe/imperative": "^4.17.2",
+        "@zowe/imperative": "^4.17.6",
         "husky": "^7.0.2",
         "jsonc": "^2.0.0",
         "ts-node": "^10.3.0",

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -11,7 +11,8 @@
 
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { WebHelpGenerator, Imperative, ImperativeConfig, IHandlerResponseApi, HandlerResponse, CommandResponse } from "@zowe/imperative";
+import { WebHelpGenerator, Imperative, ImperativeConfig, IHandlerResponseApi,
+    HandlerResponse, CommandResponse, IImperativeConfig } from "@zowe/imperative";
 import { getImperativeConfig } from "@zowe/cli";
 import { argv } from "process";
 import { jsonc as JSONC } from 'jsonc';
@@ -23,7 +24,7 @@ import { jsonc as JSONC } from 'jsonc';
     const localWebHelpDir = join(__dirname, "../", "generatedWebHelp");
     const fullCommandTree = readFileSync(filePath).toString();
     const fullCommandTreeJson = JSONC.parse(fullCommandTree).data;
-    const CLIImperativeConfig = getImperativeConfig();
+    const CLIImperativeConfig = getImperativeConfig() as IImperativeConfig;
     const fakeHandlerResponse: IHandlerResponseApi = new HandlerResponse(new CommandResponse({silent: true, responseFormat: "default"}));
 
     // Initialize Imperative and build the web help generator


### PR DESCRIPTION
Updates Imperative to resolve a bug that can result in the Web Help Generator displaying another command's information, if the intended command's name and description is identical to the other command's.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>