### PR TITLE
Add dbm-db2 and endevor conformant plugins and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ zowe.json
 tsconfig.tsbuildinfo
 package-lock.json
 .copyright
+*.bak
 zowe.config.json
 zowe.schema.json
 zowe.config.user.json

--- a/commandGroups/dbm-db2.jsonc
+++ b/commandGroups/dbm-db2.jsonc
@@ -1,0 +1,2289 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "dbm-db2",
+  "description": "dbm-db2 plug-in to interact with Db2 using the Broadcom Database Management Solutions for Db2 for z/OS.",
+  "type": "group",
+  "children": [
+    {
+      "name": "check",
+      "description": "Perform DDL syntax checking.",
+      "type": "group",
+      "children": [
+        {
+          "name": "ddl",
+          "description": "Validate the syntax of input DDL and optionally verify Db2 object dependencies. Use this command to ensure that the syntax of the input DDL is valid. You can also optionally verify that the objects to be created do not exist on the Db2 subsystem and that the related objects that are required for successful creation of the objects exist on the Db2 subsystem or in the input DDL. You can generate input DDL using the 'zowe dbm-db2 generate ddl' command.",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "required": [
+              "dbm-db2"
+            ],
+            "optional": [
+              "base"
+            ],
+            "suppressOptions": []
+          },
+          "options": [
+            {
+              "name": "target-db2",
+              "description": "Specifies the target Db2 subsystem ID where you want to validate the DDL.",
+              "type": "string",
+              "aliases": [
+                "td"
+              ],
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "verify",
+              "description": "Specifies whether to verify that the objects to be created do not exist on the Db2 subsystem and that the related objects that are required for successful creation of the objects exist on the Db2 subsystem or in the input DDL.\n \n \u001b[90m Default value: no \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "v"
+              ],
+              "allowableValues": {
+                "values": [
+                  "yes",
+                  "no"
+                ]
+              },
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "modification",
+              "description": "Identifies an existing named set of server-managed default parameter values that control the execution behavior of the zowe dbm-db2 commands. For example, you can use a modification to identify a set of default values that differ from the set of values that are normally used.\n \n \u001b[90m For more information about using the modification option, see the DBM Data Service documentation at https://techdocs.broadcom.com/db2mgmt. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "m"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "error-file",
+              "description": "Specifies the local output error file in YAML format that contains errors that occurred during execution of the command.\n \n \u001b[90m Default value: error.log \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ef"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "dbm-db2-profile",
+              "aliases": [
+                "dbm-db2-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (dbm-db2) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "positionals": [
+            {
+              "name": "local-input-ddl-filename",
+              "description": "Specifies the local input file that contains the DDL statements for the Db2 objects that you want to validate on a target subsystem. Typically, this file is created by a 'zowe dbm-db2 generate ddl' command or retrieved from an archive. You can edit this file. ",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "examples": [
+            {
+              "options": "sample.sql --target-db2 TEST",
+              "description": "Validate DDL statement syntax of the DDL statements in the sample.sql file on the 'TEST' Db2 subsystem"
+            },
+            {
+              "options": "sample.sql --target-db2 TEST --verify yes",
+              "description": "Validate DDL statement syntax and verify object dependencies"
+            }
+          ],
+          "aliases": [],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": [],
+      "passOn": []
+    },
+    {
+      "name": "compare",
+      "description": "Compare DDL with a Db2 subsystem and produce an update script to implement changes.",
+      "type": "group",
+      "children": [
+        {
+          "name": "ddl",
+          "description": "Compare objects that are defined in a DDL file to objects that are defined on a Db2 subsystem and generate an update script to implement the necessary object changes. This command also generates a summary report that provides a high-level overview of the changes. You can execute the script that is generated from this command using the 'zowe dbm-db2 execute compare-script' command.",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "required": [
+              "dbm-db2"
+            ],
+            "optional": [
+              "base"
+            ],
+            "suppressOptions": []
+          },
+          "options": [
+            {
+              "name": "target-db2",
+              "description": "Specifies the target Db2 subsystem ID where the objects that you are comparing reside.",
+              "type": "string",
+              "aliases": [
+                "td"
+              ],
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "match-set",
+              "description": "Specifies the creator and name of an existing RC/Migrator automapping mask set. Matching is used to pair objects in a DDL file to objects that are defined on a Db2 subsystem. Matching determines whether the 'change-set' or 'rule-set' options are applied.\n\n\u001b[90m Format:\n\n<match-set-creator.match-set-name>\n\nFor more information about mask services, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig.\n\nNote: If --match-set and --match-set-file are both specified, specifications in match-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ms"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "match-set-file",
+              "description": "Specifies the name of the local input file that contains the mapping mask specifications. Matching is used to pair objects in a DDL file to objects that are defined on a Db2 subsystem. For example, a mask specification can account for different schema naming patterns across environments. Matching determines whether the 'change-set' or 'rule-set' options are applied.\n                    \n\u001b[90m Format:\n\n<object-type> <source-name-mask> <target-name-mask>;\n\nSTOGROUP <name> <name>\nDATABASE <name> <name>\nTABLESPACE <database.name> <database.name>\nTABLE <schema.name> <schema.name>\nINDEX <schema.name> <schema.name>\nVIEW <schema.name> <schema.name>\nSYNONYM <schema.name> <schema.name>\nALIAS <schema.name> <schema.name>\nTRIGGER <schema.name> <schema.name>\nSEQUENCE <schema.name> <schema.name>\nFUNCTION <schema.name[.version]> <schema.name[.version]>\nPROCEDURE <schema.name[.version]> <schema.name[.version]>\n                        \nNote: <schema> must be 8 characters or less. <name> must be 18 characters or less. The SEQUENCE <name> must be 8 characters or less.\n                    \nA mask specification can include the following wildcard characters:\n                    \n% (percent sign) indicates that zero or more characters can occupy that position. Other non-wildcard characters must match.\n \n- (hyphen) indicates that any character can occupy that position, but a character must exist at that position.\n \n* (asterisk) indicates that like named objects on the source and target should be mapped. No other characters can appear together with this character.\n                    \nUse a semicolon to separate mask specifications. Multiple mask specifications for the same object type are supported.\n\nExample:\n \nThe following example demonstrates different ways of matching the table MYNAME.MYTABLE to the table YOURNAME.YOURTABLE:\n \nTABLE MY%.%TABLE YOUR%.%TABLE; \nTABLE MYN-M-.MYT% YOURN-M-.YOURT%;\nTABLE MYNAME.MYTABLE YOURNAME.YOURTABLE; \nTABLE *.MYTABLE *.YOURTABLE;\n\nFor a list of mask specifications, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig.\n \nNote: If --match-set and --match-set-file are both specified, specifications in match-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "conflictsWith": [
+                "match-set"
+              ],
+              "aliases": [
+                "msf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "change-set",
+              "description": "Specifies the creator and name of an existing RC/Migrator global change set to be used to modify Db2 object attributes. The changes apply to new objects only as determined by match-set processing.\n\n\u001b[90m Format:\n\n<change-set-creator.change-set-name>\n \nFor more information about global change services, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig. \n        \nNote: If change-set and change-set-file are both specified, specifications in change-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "cs"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "change-set-file",
+              "description": "Specifies the name of the local input file that contains the global change specifications to modify Db2 object attributes. The changes apply to new objects only as determined by match-set processing. \n                    \n\u001b[90m Format:\n\n<object-attribute> <from-value> <to-value>\n                    \nThe <object-attribute> consists of four characters. The first two characters identify the object type. The last two characters identify the specific attribute. Wildcard characters are supported in the <from-value> and <to-value>. The first occurrence in multiple specifications for the same <object-attribute> has the highest precedence.\n \nExample:\n \nThe following example demonstrates changes to table’s schema (creator) and tablespace names:\n \nTBCR TEST% PROD%\nTBTS TESTTS% PRODTS%\n                   \nFor a list of global change set attributes, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig.\n         \nNote: If change-set and change-set-file are both specified, specifications in change-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "csf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "rule-set",
+              "description": "Specifies the creator and name of an existing RC/Migrator rule set to be used to override Db2 object attributes in the target Db2 subsystem with the corresponding values from the input DDL file.The changes apply to the existing objects only (as determined by match-set processing).\n\n\u001b[90m Format:\n\n<rule-set-creator.rule-set-name>\n         \nFor more information about rule database services, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "rs"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "id",
+              "description": "Specifies the 1- to 8-character name of the RC/Migrator compare strategy that is created on the target Db2 subsystem by the execution of this command.\n \n\u001b[90m Format: The name must begin with a non-numeric character, and can consist of the characters A to Z (uppercase only), 0 to 9, $, #, and @. \u001b[0m",
+              "type": "string",
+              "required": false,
+              "group": "Options",
+              "aliases": []
+            },
+            {
+              "name": "description",
+              "description": "Specifies a 1- to 25-character description for the RC/Migrator compare strategy.",
+              "type": "string",
+              "aliases": [
+                "d"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "output-compare-script",
+              "description": "Specifies the local output file name that contains the update script to make changes to the target Db2 subsystem.\n      \n\u001b[90m Default value: compare.txt \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ocs"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "output-summary-file",
+              "description": "Specifies the local output file name that provides a summary of the changes to be performed to the Db2 objects on the target Db2 subsystem. The file summarizes what the changes are, but not how the changes are made.\n      \n\u001b[90m Default value: summary.txt \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "osf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "modification",
+              "description": "Identifies a named set of server-managed default parameter values that control the execution behavior of the zowe dbm-db2 commands. For example, you can use a modification to identify a set of default values that differ from the set of values that are normally used.\n \n\u001b[90m For more information about using the modification option, see the DBM Data Service documentation at https://techdocs.broadcom.com/db2mgmt. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "m"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "error-file",
+              "description": "Specifies the local output error file in YAML format that contains errors that occurred during execution of the command.\n \n\u001b[90m Default value: error.log \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ef"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "dbm-db2-profile",
+              "aliases": [
+                "dbm-db2-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (dbm-db2) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "positionals": [
+            {
+              "name": "local-input-ddl-filename",
+              "description": "Specifies the local input file that contains DDL statements for the Db2 objects that you want to compare to Db2 objects on a target subsystem. Typically, this file is created by a 'zowe dbm-db2 generate ddl' command or retrieved from an archive. You can edit this file.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "examples": [
+            {
+              "options": "myddl.sql --target-db2 TEST",
+              "description": "Generate a script to update objects on the 'TEST' Db2 subsystem with DDL definitions in myddl.sql file"
+            },
+            {
+              "options": "myddl.sql --target-db2 TEST --rule-set USER1.RULESET",
+              "description": "Generate a script to update objects and apply a rule-set for the matched objects"
+            },
+            {
+              "options": "myddl.sql --target-db2 TEST --rule-set USER1.RULESET --match-set-file pair.txt",
+              "description": "Generate a script to update objects and apply a ruleset for the objects matched as determined by the local mask specifications in the pair.txt file"
+            }
+          ],
+          "aliases": [],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": [],
+      "passOn": []
+    },
+    {
+      "name": "deploy",
+      "description": "Deploy DDL statements to a Db2 subsystem.",
+      "type": "group",
+      "children": [
+        {
+          "name": "ddl",
+          "description": "Deploy Db2 object changes on the target Db2 subsystem using an input file that contains the DDL. For example, an application developer has made changes to DDL in a local file and is ready to test the DDL changes. Use this command to deploy the changes to the test environment.",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "required": [
+              "dbm-db2"
+            ],
+            "optional": [
+              "base"
+            ],
+            "suppressOptions": []
+          },
+          "options": [
+            {
+              "name": "target-db2",
+              "description": "Specifies the target Db2 subsystem ID.",
+              "type": "string",
+              "aliases": [
+                "td"
+              ],
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "match-set",
+              "description": "Specifies the creator and name of an existing RC/Migrator automapping mask set. Matching is used to pair objects in a DDL file to objects that are defined on a Db2 subsystem. Matching determines whether the 'change-set' or 'rule-set' options are applied.\n\n\u001b[90m Format:\n\n<match-set-creator.match-set-name> \n\nFor more information about mask services, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig.\n\nNote: If --match-set and --match-set-file are both specified, specifications in match-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ms"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "match-set-file",
+              "description": "Specifies the name of the local input file that contains the mapping mask specifications. Matching is used to pair objects in a DDL file to objects that are defined on a Db2 subsystem. For example, a mask specification can account for different schema naming patterns across environments. Matching determines whether the 'change-set' or 'rule-set' options are applied.\n                    \n\u001b[90m Format:\n\n<object-type> <source-name-mask> <target-name-mask>;\n\nSTOGROUP <name> <name>\nDATABASE <name> <name>\nTABLESPACE <database.name> <database.name>\nTABLE <schema.name> <schema.name>\nINDEX <schema.name> <schema.name>\nVIEW <schema.name> <schema.name>\nSYNONYM <schema.name> <schema.name>\nALIAS <schema.name> <schema.name>\nTRIGGER <schema.name> <schema.name>\nSEQUENCE <schema.name> <schema.name>\nFUNCTION <schema.name[.version]> <schema.name[.version]>\nPROCEDURE <schema.name[.version]> <schema.name[.version]>\n                        \nNote: <schema> must be 8 characters or less. <name> must be 18 characters or less. The SEQUENCE <name> must be 8 characters or less.\n                    \nA mask specification can include the following wildcard characters:\n                    \n% (percent sign) indicates that zero or more characters can occupy that position. Other non-wildcard characters must match.\n \n- (hyphen) indicates that any character can occupy that position, but a character must exist at that position.\n \n* (asterisk) indicates that like named objects on the source and target should be mapped. No other characters can appear together with this character.\n                    \nUse a semicolon to separate mask specifications. Multiple mask specifications for the same object type are supported.\n\nExample:\n \nThe following example demonstrates different ways of matching the table MYNAME.MYTABLE to the table YOURNAME.YOURTABLE:\n \nTABLE MY%.%TABLE YOUR%.%TABLE; \nTABLE MYN-M-.MYT% YOURN-M-.YOURT%;\nTABLE MYNAME.MYTABLE YOURNAME.YOURTABLE; \nTABLE *.MYTABLE *.YOURTABLE;\n\nFor a list of mask specifications, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig.\n \nNote: If --match-set and --match-set-file are both specified, specifications in match-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "conflictsWith": [
+                "match-set"
+              ],
+              "aliases": [
+                "msf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "change-set",
+              "description": "Specifies the creator and name of an existing RC/Migrator global change set to be used to modify Db2 object attributes. The changes apply to new objects only as determined by match-set processing.\n\n\u001b[90m Format:\n\n<change-set-creator.change-set-name>\n \nFor more information about global change services, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig. \n        \nNote: If change-set and change-set-file are both specified, specifications in change-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "cs"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "change-set-file",
+              "description": "Specifies the name of the local input file that contains the global change specifications to modify Db2 object attributes. The changes apply to new objects only as determined by match-set processing. \n                    \n\u001b[90m Format:\n\n<object-attribute> <from-value> <to-value>\n                    \nThe <object-attribute> consists of four characters. The first two characters identify the object type. The last two characters identify the specific attribute. Wildcard characters are supported in the <from-value> and <to-value>. The first occurrence in multiple specifications for the same <object-attribute> has the highest precedence.\n \nExample:\n \nThe following example demonstrates changes to table’s schema (creator) and tablespace names:\n \nTBCR TEST% PROD%\nTBTS TESTTS% PRODTS%\n                   \nFor a list of global change set attributes, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig.\n         \nNote: If change-set and change-set-file are both specified, specifications in change-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "csf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "rule-set",
+              "description": "Specifies the creator and name of an existing RC/Migrator rule set to be used to override Db2 object attributes in the target Db2 subsystem with the corresponding values from the input DDL file.The changes apply to the existing objects only (as determined by match-set processing).\n\n\u001b[90m Format:\n\n<rule-set-creator.rule-set-name>\n         \nFor more information about rule database services, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "rs"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "modification",
+              "description": "Identifies a named set of server-managed default parameter values that control the execution behavior of the zowe dbm-db2 commands. For example, you can use a modification to identify a set of default values that differ from the set of values that are normally used.\n \n\u001b[90m For more information about using the modification option, see the DBM Data Service documentation at https://techdocs.broadcom.com/db2mgmt. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "m"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "error-file",
+              "description": "Specifies the local output error file in YAML format that contains errors that occurred during execution of the command.\n \n\u001b[90m Default value: error.log \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ef"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "dbm-db2-profile",
+              "aliases": [
+                "dbm-db2-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (dbm-db2) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "positionals": [
+            {
+              "name": "local-input-ddl-filename",
+              "description": "Specifies the local input file that contains DDL statements for the Db2 objects that you want to deploy on a target subsystem. Typically, this file is created by a 'zowe dbm-db2 generate ddl' command or retrieved from an archive. You can edit this file.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "examples": [
+            {
+              "options": "myddl.sql --target-db2 TEST",
+              "description": "Update Db2 objects on a target Db2 subsystem according to DDL definitions in myddl.sql file"
+            },
+            {
+              "options": "myddl.sql --target-db2 TEST --rule-set USER1.RULESET",
+              "description": "Update Db2 objects according to the input DDL definitions and applied rule set for the matched objects"
+            },
+            {
+              "options": "myddl.sql --target-db2 TEST --rule-set USER1.RULESET --match-set-file pair.txt",
+              "description": "Update Db2 objects according to the input DDL definitions and applied rule set for the objects matched as determined by the local mask specifications in the pair.txt file"
+            }
+          ],
+          "aliases": [],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": [],
+      "passOn": []
+    },
+    {
+      "name": "execute",
+      "description": "Execute a script to implement Db2 object changes.",
+      "type": "group",
+      "children": [
+        {
+          "name": "compare-script",
+          "description": "Execute the compare script that was generated with the 'zowe dbm-db2 compare ddl' command to implement the Db2 object changes on the Db2 subsystem specified within the script. This command also generates a recovery script to undo compare script changes.\n ",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "required": [
+              "dbm-db2"
+            ],
+            "optional": [
+              "base"
+            ],
+            "suppressOptions": []
+          },
+          "options": [
+            {
+              "name": "output-recovery-file",
+              "description": "Specifies the local output recovery file that contains the recovery script that is generated during execution of this command. Executing the recovery script using the 'zowe dbm-db2 execute script' command undoes the changes that were made by execution of the compare-script. \n      \n\u001b[90m Default value: recovery.txt \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "orf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "restart",
+              "description": "Specifies the location in the script where you want to restart execution. The effects of previous successful script statement executions remain. \n \nThe following restart options are valid:\n      \nnew - Restart execution of the script at the first statement. \n      \ntoken - Restart execution of the script at the location that is recorded in the specified token and that was returned from a previous execution failure.",
+              "type": "string",
+              "aliases": [
+                "r"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "modification",
+              "description": "Identifies a named set of server-managed default parameter values that control the execution behavior of the zowe dbm-db2 commands. For example, you can use a modification to identify a set of default values that differ from the set of values that are normally used.\n \n\u001b[90m For more information about using the modification option, see the DBM Data Service documentation at https://techdocs.broadcom.com/db2mgmt. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "m"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "error-file",
+              "description": "Specifies the local output error file in YAML format that contains errors that occurred during execution of the command.\n \n\u001b[90m Default value: error.log \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ef"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "dbm-db2-profile",
+              "aliases": [
+                "dbm-db2-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (dbm-db2) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "positionals": [
+            {
+              "name": "local-input-compare-script-filename",
+              "description": "Specifies the local input compare-script file that contains the update script that was generated with the 'zowe dbm-db2 compare ddl' command.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "examples": [
+            {
+              "options": "compare.txt",
+              "description": "Execute a compare script"
+            },
+            {
+              "options": "compare.txt --restart new",
+              "description": "Restart execution of a compare script at the first statement in the script"
+            },
+            {
+              "options": "compare.txt --restart 78A724GOBLEDYGOOK6FD140F6780D6FA",
+              "description": "Restart execution of a compare script at the location in the token"
+            }
+          ],
+          "aliases": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "script",
+          "description": "Execute a Batch Processor script on a target subsystem. For example, use this command to execute a Batch Processor script or specifically to execute a recovery script to undo changes that were made by the 'zowe dbm-db2 execute compare-script' command. If execution of the script fails, you can execute it again using the 'script-section' or 'restart' options. You can edit the script and make changes before you execute or restart it.\n ",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "required": [
+              "dbm-db2"
+            ],
+            "optional": [
+              "base"
+            ],
+            "suppressOptions": []
+          },
+          "options": [
+            {
+              "name": "target-db2",
+              "description": "Specifies the target Db2 subsystem ID where you want to execute the script. If the option is not specified, the target subsystem is identified by the first .CONNECT statement in the script. The target-db2 option value takes precedence.",
+              "type": "string",
+              "aliases": [
+                "td"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "script-section",
+              "description": "Identifies the location in the script where you want to begin execution. \n\nThe following options are valid:\n\nname - Begin execution of the specific section and process all subsequent statements up to the next section.\n\nA section is a '.SYSTEM <name>' statement, where <name> identifies a logical grouping of statements such as UNLOADS or SQLDDL. 'source' is an alias for UNLOADS. 'target' is an alias for SQLDDL.\n \nnumber - Begin execution after the specific sync point (.SYNC <number> statement) and process all statements up to the end of the script.\n \nname, number - Begin execution of the specific script section beginning from the sync point (.SYNC <number> statement) within the section and process all subsequent statements up to the next section.",
+              "type": "string",
+              "aliases": [
+                "ss"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "restart",
+              "description": "Specifies the location in the script where you want to restart execution. The effects of previous successful script statement executions remain. \n \nThe following restart options are valid:\n        \nnew - Restart execution of the script at the first statement.\n         \ntoken - Restart execution of the script at the location that is recorded in the specified token and that was returned from a previous execution failure.\n \nname, token - Restart execution of the script at the location in the restart section that is recorded in the specified token and that was returned from a prior execution failure.\n        \nA section is a Batch Processor '.SYSTEM <name>' statement, where <name> identifies a logical grouping of statements such as UNLOADS or SQLDDL. 'source' is an alias for UNLOADS. 'target' is an alias for SQLDDL.",
+              "type": "string",
+              "aliases": [
+                "r"
+              ],
+              "conflictsWith": [
+                "script-section"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "modification",
+              "description": "Identifies a named set of server-managed default parameter values that control the execution behavior of the zowe dbm-db2 commands. For example, you can use a modification to identify a set of default values that differ from the set of values that are normally used.\n \n\u001b[90m For more information about using the modification option, see the DBM Data Service documentation at https://techdocs.broadcom.com/db2mgmt. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "m"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "error-file",
+              "description": "Specifies the local output error file in YAML format that contains errors that occurred during execution of the command.\n      \n\u001b[90m Default value: error.log \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ef"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "dbm-db2-profile",
+              "aliases": [
+                "dbm-db2-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (dbm-db2) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "positionals": [
+            {
+              "name": "local-input-bp-script-filename",
+              "description": "Specifies the local input file that contains the Batch Processor statements such as the recovery script that was created by executing the 'zowe dbm-db2 execute compare-script' command.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "examples": [
+            {
+              "options": "recovery.txt",
+              "description": "Execute a recovery script"
+            },
+            {
+              "options": "script001.txt --target-db2 TEST",
+              "description": "Execute a script on the 'TEST' Db2 subsystem"
+            },
+            {
+              "options": "script001.txt ––script-section SQLDDL",
+              "description": "Execute only the SQLDDL section of a script. The first .CONNECT statement in the script identifies the target subsystem where the script is executed. Execution begins at the .SYSTEM SQLDDL statement and ends at the next .SYSTEM statement in the script"
+            },
+            {
+              "options": "script001.txt ––script-section 10",
+              "description": "Execute a script beginning from the sync point 10 (.SYNC 10 statement) to the end of the script"
+            },
+            {
+              "options": "script001.txt ––script-section target,20",
+              "description": "Execute only the target (SQLDDL) section of the script starting at sync point 20"
+            },
+            {
+              "options": "script001.txt ––restart new",
+              "description": "Restart execution of a script from the beginning"
+            },
+            {
+              "options": "script001.txt ––restart 78A724A48DA5185D06FD140F6780D6FA",
+              "description": "Restart execution of a script at the location specified in the token. The restart token is returned by a previous 'zowe dbm-db2 execute command' failure as part of the terminal output and in the error file"
+            },
+            {
+              "options": "script001.txt ––restart target,78A724A48DA5185D06FD140F6780D6FA",
+              "description": "Restart execution at the last successful sync point recorded in the restart token up to the end of the target (SQLDDL) section"
+            }
+          ],
+          "aliases": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "migration-script",
+          "description": "Execute the migration script that was generated with the 'zowe dbm-db2 prepare migration' command to migrate Db2 objects (DDL) and table data from a source subsystem to a target subsystem. The source and target subsystem IDs are specified within the script.\n ",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "required": [
+              "dbm-db2"
+            ],
+            "optional": [
+              "base"
+            ],
+            "suppressOptions": []
+          },
+          "options": [
+            {
+              "name": "restart",
+              "description": "Specifies the location in the script where you want to restart execution. The effects of previous successful script statement executions remain. \n \nThe following restart options are valid:\n        \nnew - Restart execution of the script at the first statement.\n        \nname, token - Restart execution of the script at the location in the restart section that is recorded in the specified token and that was returned from a prior execution failure.\n  \nA section is a '.SYSTEM <name>' statement, where <name> identifies a logical grouping of statements such as UNLOADS or SQLDDL. 'source' is an alias for UNLOADS. 'target' is an alias for SQLDDL.",
+              "type": "string",
+              "aliases": [
+                "r"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "modification",
+              "description": "Identifies a named set of server-managed default parameter values that control the execution behavior of the zowe dbm-db2 commands. For example, you can use a modification to identify a set of default values that differ from the set of values that are normally used.\n \n\u001b[90m For more information about using the modification option, see the DBM Data Service documentation at https://techdocs.broadcom.com/db2mgmt. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "m"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "error-file",
+              "description": "Specifies the local output error file in YAML format that contains errors that occurred during execution of the command.\n \n\u001b[90m Default value: error.log \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ef"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "dbm-db2-profile",
+              "aliases": [
+                "dbm-db2-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (dbm-db2) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "positionals": [
+            {
+              "name": "local-input-migrate-script-filename",
+              "description": "Specifies the local input migration-script file that was generated with the 'zowe dbm-db2 prepare migration' command.",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "examples": [
+            {
+              "options": "migration.txt",
+              "description": "Execute a migration script"
+            },
+            {
+              "options": "migration.txt --restart new",
+              "description": "Restart execution of a migration script at the first statement in the script"
+            },
+            {
+              "options": "migration.txt --restart target,78A724GOBLEDYGOOK6FD140F6780D6FA",
+              "description": "Restart execution of a migration script at the location in the token. Execution begins at the last successful sync point that is recorded in the restart token up to the end of the restart token section"
+            }
+          ],
+          "aliases": [],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": [],
+      "passOn": []
+    },
+    {
+      "name": "generate",
+      "description": "Generate DDL statements for Db2 objects.",
+      "type": "group",
+      "children": [
+        {
+          "name": "ddl",
+          "description": "Generate CREATE or DROP DDL statements for specified Db2 objects into an output DDL file. For example, use this command to generate CREATE TABLE definitions that you can then edit and use to update the table definition on a Db2 subsystem with the 'zowe dbm-db2 compare ddl' command.",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "required": [
+              "dbm-db2"
+            ],
+            "optional": [
+              "base"
+            ],
+            "suppressOptions": []
+          },
+          "options": [
+            {
+              "name": "object",
+              "description": "Specifies the Db2 objects for which you want to generate DDL statements. Use the optional include syntax to include related Db2 objects.\n      \n\u001b[90m Format: see object-file description.\n\nNote: The --object and --object-file options are mutually exclusive. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "o"
+              ],
+              "group": "Options"
+            },
+            {
+              "name": "object-file",
+              "description": "Specifies the local input file that contains a list of Db2 objects, separated by a semicolon, for which you want to generate DDL statements. Use the optional include syntax to include related Db2 objects.\n      \n\u001b[90m Format:\n\n<object-type> <object-name> [include(<related-object-type>,...)];\n\nThe required clause <object-type> <object-name>  identifies the specific Db2 (base) object:\n     \nSTOGROUP <name>\nDATABASE <name>\nTABLESPACE <dbname.name>\nTABLE <schema.name>\nINDEX <schema.name>\nVIEW <schema.name>\nALIAS <schema.name>\nSYNONYM <schema.name>\nMQT <schema.name>\nSEQUENCE <schema.name>\nTRIGGER <schema.name>\nFUNCTION <schema.name[.version]>\nPROCEDURE <schema.name[.version]>\n\nThe optional clause include(<related-object-type>,...) identifies one or more, comma separated related object types that you want to include in the generated DDL statements. You can specify STOGROUP, DATABASE, TABLESPACE, TABLE, INDEX, VIEW, SYNONYM, MQT-ALL, TRIGGER, ROUTINE, PARENTS, CHILDREN, and ALL.\n     \nExample:\n     \ntable sysibm.systables include (tablespace, database, index);\ndatabase db1 include(children);\n\nNote: The --object and --object-file options are mutually exclusive. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "of"
+              ],
+              "conflictsWith": [
+                "object"
+              ],
+              "group": "Options"
+            },
+            {
+              "name": "source-db2",
+              "description": "Specifies the source Db2 subsystem ID where the objects that you want to generate DDL for are located.",
+              "type": "string",
+              "aliases": [
+                "sd"
+              ],
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "change-set",
+              "description": "Specifies the creator and name of an existing RC/Migrator global change set to be used to modify Db2 object attributes when generating the DDL.\n\n\u001b[90m Format:\n \n<change-set-creator.change-set-name> \n\nFor more information about global change services, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig. \n \nNote: If change-set and change-set-file are both specified, specifications in change-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "cs"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "change-set-file",
+              "description": "Specifies the name of the local input file that contains the global change specifications to modify Db2 object attributes when generating DDL.\n\n\u001b[90m Format:\n \n<object-attribute> <from-value> <to-value>\n    \nThe <object-attribute> consists of four characters. The first two characters identify the object type. The last two characters identify the specific attribute. Wildcard characters are supported in the <from-value> and <to-value>. The first occurrence in multiple specifications for the same <object-attribute> has the highest precedence.\n   \nFor a list of global change set attributes, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig.\n \nExample:\n    \nThe following example demonstrates changes to table’s schema (creator) and tablespace names:\n     \nTBCR TEST% PROD%\nTBTS TESTTS% PRODTS%\n\nNote: If change-set and change-set-file are both specified, specifications in change-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "csf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "type",
+              "description": "Specifies the type of DDL statements that you want to generate. You can generate CREATE or DROP statements.",
+              "type": "string",
+              "aliases": [
+                "t"
+              ],
+              "required": false,
+              "allowableValues": {
+                "values": [
+                  "drop",
+                  "create"
+                ]
+              },
+              "defaultValue": "create",
+              "group": "Options"
+            },
+            {
+              "name": "output-ddl-file",
+              "description": "Specifies the local output file name that contains the generated DDL for the objects that are identified by the --object-file or --object option.\n      \n\u001b[90m Default value: output.sql \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "odf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "modification",
+              "description": "Identifies a named set of server-managed default parameter values that control the execution behavior of the zowe dbm-db2 commands. For example, you can use a modification to identify a set of default values that differ from the set of values that are normally used.\n \n\u001b[90m For more information about using the modification option, see the DBM Data Service documentation at https://techdocs.broadcom.com/db2mgmt. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "m"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "error-file",
+              "description": "Specifies the local output error file in YAML format that contains errors that occurred during execution of the command.\n       \n\u001b[90m Default value: error.log \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ef"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "dbm-db2-profile",
+              "aliases": [
+                "dbm-db2-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (dbm-db2) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "examples": [
+            {
+              "options": "--object \"tablespace my.tbsp include(table)\" --source-db2 SRC --output-ddl-file objects.sql",
+              "description": "Generate CREATE DDL statements for a tablespace and its child table"
+            },
+            {
+              "options": "--object \"database my.db include(children)\" --source-db2 SRC --change-set USER1.CHANGSET --output-ddl-file objects.sql",
+              "description": "Generate CREATE DDL statements for a database and its children and apply changes as defined in the change set"
+            },
+            {
+              "options": "--object-file objects.txt --source-db2 SRC --type drop --output-ddl-file output.sql",
+              "description": "Generate DROP DDL statements only for the input object list"
+            }
+          ],
+          "mustSpecifyOne": [
+            "object-file",
+            "object"
+          ],
+          "aliases": [],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": [],
+      "passOn": []
+    },
+    {
+      "name": "prepare",
+      "description": "Prepare DDL statements and a script to migrate Db2 objects.",
+      "type": "group",
+      "children": [
+        {
+          "name": "migration",
+          "description": "Generate a script to migrate Db2 object definitions (DDL) and data from a source subsystem to a target subsystem. You can specify which objects to include and apply changes to the objects as part of the migration. To execute the script, use the 'zowe dbm-db2 execute migration-script' command.",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "required": [
+              "dbm-db2"
+            ],
+            "optional": [
+              "base"
+            ],
+            "suppressOptions": []
+          },
+          "options": [
+            {
+              "name": "object",
+              "description": "Specifies the Db2 objects that you want to migrate. Use the optional include syntax to include related Db2 objects.\n     \n\u001b[90m Format: see object-file description.\n\nNote: The --object and --object-file options are mutually exclusive. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "o"
+              ],
+              "group": "Options"
+            },
+            {
+              "name": "object-file",
+              "description": "Specifies the local input file that contains a list of Db2 objects, separated by a semicolon, that you want to migrate. Use the optional include syntax to include related Db2 objects.\n      \n\u001b[90m Format:\n\n<object-type> <object-name> [include(<related-object-type>,...)];\n\nThe required clause <object-type> <object-name>  identifies the specific Db2 (base) object:\n     \nSTOGROUP <name>\nDATABASE <name>\nTABLESPACE <dbname.name>\nTABLE <schema.name>\nINDEX <schema.name>\nVIEW <schema.name>\nALIAS <schema.name>\nSYNONYM <schema.name>\nMQT <schema.name>\nSEQUENCE <schema.name>\nTRIGGER <schema.name>\nFUNCTION <schema.name[.version]>\nPROCEDURE <schema.name[.version]>\n\nThe optional clause include(<related-object-type>,...) identifies one or more, comma separated related object types that you want to include in the object list. You can specify STOGROUP, DATABASE, TABLESPACE, TABLE, INDEX, VIEW, SYNONYM, MQT-ALL, TRIGGER, ROUTINE, PARENTS, CHILDREN, and ALL.\n     \nExample:\n     \ntable sysibm.systables include (tablespace, database, index);\ndatabase db1 include(children);\n\nNote: The --object and --object-file options are mutually exclusive. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "of"
+              ],
+              "conflictsWith": [
+                "object"
+              ],
+              "group": "Options"
+            },
+            {
+              "name": "source-db2",
+              "description": "Specifies the source Db2 subsystem ID where the object definitions and data that you want to migrate are located.",
+              "type": "string",
+              "aliases": [
+                "sd"
+              ],
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "target-db2",
+              "description": "Specifies the target Db2 subsystem ID where the object definitions and data are migrated (copied) to.",
+              "type": "string",
+              "aliases": [
+                "td"
+              ],
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "change-set",
+              "description": "Specifies the creator and name of an existing RC/Migrator global change set to be used to modify Db2 object attributes when preparing objects for migration. \n\n\u001b[90m Format:\n \n<change-set-creator.change-set-name> \n\nFor more information about global change services, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig. \n \nNote: If change-set and change-set-file are both specified, specifications in change-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "cs"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "change-set-file",
+              "description": "Specifies the name of the local input file that contains the global change specifications to modify Db2 object attributes when preparing for migration.\n\n\u001b[90m Format:\n \n<object-attribute> <from-value> <to-value>\n    \nThe <object-attribute> consists of four characters. The first two characters identify the object type. The last two characters identify the specific attribute. Wildcard characters are supported in the <from-value> and <to-value>. The first occurrence in multiple specifications for the same <object-attribute> has the highest precedence.\n   \nFor a list of global change set attributes, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig.\n \nExample:\n    \nThe following example demonstrates changes to table’s schema (creator) and tablespace names:\n     \nTBCR TEST% PROD%\nTBTS TESTTS% PRODTS%\n  \nNote: If change-set and change-set-file are both specified, specifications in change-set-file take precedence. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "csf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "output-migrate-script",
+              "description": "Specifies the local output file name that contains the script to make changes to the target Db2 subsystem.\n  \n\u001b[90m Default value: migration.txt \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "oms"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "output-ddl-file",
+              "description": "Specifies the local output file name that contains the generated DDL for the input objects that are identified by the --object-file or --object option.\n \n\u001b[90m Default value: output.sql \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "odf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "modification",
+              "description": "Identifies a named set of server-managed default parameter values that control the execution behavior of the zowe dbm-db2 commands. For example, you can use a modification to identify a set of default values that differ from the set of values that are normally used.\n \n\u001b[90m For more information about using the modification option, see the DBM Data Service documentation at https://techdocs.broadcom.com/db2mgmt. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "m"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "error-file",
+              "description": "Specifies the local output error file in YAML format that contains errors that occurred during execution of the command.\n      \n\u001b[90m Default value: error.log \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "ef"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "dbm-db2-profile",
+              "aliases": [
+                "dbm-db2-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (dbm-db2) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "examples": [
+            {
+              "options": "--object \"tablespace my.tbsp include(table)\" --source-db2 SRC --target-db2 TRG --output-migrate-script migrate.txt",
+              "description": "Generate a migration script for a tablespace and its child table"
+            },
+            {
+              "options": "--object \"database my.db include(children)\" --source-db2 SRC --target-db2 TRG –-change-set USER1.CHANGSET –-output-migrate-script migrate.txt --output-ddl-file objects.sql",
+              "description": "Generate a migration script and apply global changes"
+            }
+          ],
+          "mustSpecifyOne": [
+            "object-file",
+            "object"
+          ],
+          "aliases": [],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": [],
+      "passOn": []
+    }
+  ],
+  "summary": "Interact with Db2 using the Broadcom Database Management Solutions for Db2 for z/OS.",
+  "aliases": [
+    "dbm"
+  ],
+  "options": [
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "positionals": [],
+  "passOn": []
+}

--- a/commandGroups/endevor.jsonc
+++ b/commandGroups/endevor.jsonc
@@ -1,0 +1,19303 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor",
+  "description": "Endevor plug-in for listing Endevor environment information, working with elements and packages located in specified Endevor instance.",
+  "type": "group",
+  "children": [
+    {
+      "name": "add",
+      "type": "group",
+      "description": "Add an Element into Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sys SYS --sub SUB --typ TYPE --ff localfile.txt -i ENDEVOR",
+              "description": "Add element from local file with endevor profile set up"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The add element command lets you add an Element to an Environment entry Stage in Endevor.",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "from-file",
+              "aliases": [
+                "ff"
+              ],
+              "description": "Use this input to provide source file.",
+              "type": "string",
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-package",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-dataset",
+              "aliases": [
+                "fd"
+              ],
+              "description": "Use this input to provide source data set name.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                44
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-member",
+              "aliases": [
+                "fm"
+              ],
+              "description": "Use this input to provide source member name in the data set.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-path",
+              "aliases": [
+                "fp"
+              ],
+              "description": "Use this input to provide the path of source USS file. It must be used with from-uss-file.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                768
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-dataset",
+                "from-member",
+                "from-text"
+              ],
+              "implies": [
+                "from-uss-file"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-uss-file",
+              "aliases": [
+                "fuf"
+              ],
+              "description": "Use this input to provide source USS file name. It must be used with from-path",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-dataset",
+                "from-member",
+                "from-text"
+              ],
+              "implies": [
+                "from-path"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "override-signout",
+              "aliases": [
+                "os"
+              ],
+              "description": "Specify if you want to override the Signout of an Endevor element while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "new-version",
+              "aliases": [
+                "nv"
+              ],
+              "description": "Assign a different version number to the Element.",
+              "type": "number",
+              "numericValueRange": [
+                1,
+                99
+              ],
+              "group": "options"
+            },
+            {
+              "name": "proc-group",
+              "aliases": [
+                "pg"
+              ],
+              "description": "The Endevor processor group you would like to use.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "generate",
+              "aliases": [
+                "g"
+              ],
+              "description": "Specifies if you want to Generate Element after Add/Update action.",
+              "type": "boolean",
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "get-fingerprint",
+              "aliases": [
+                "gfg"
+              ],
+              "description": "Return fingerprint of a retrieved, added or updated element as the first line of the response.",
+              "type": "boolean",
+              "defaultValue": false,
+              "group": "options"
+            },
+            {
+              "name": "fingerprint",
+              "aliases": [
+                "fg"
+              ],
+              "description": "Specifies the fingerprint of the element to Add or Update. Use value 'NEW' when adding a new element that shouldn't exist in the map yet.",
+              "type": "string",
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-path",
+                "from-uss-file"
+              ],
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "approve",
+      "aliases": [
+        "aprv"
+      ],
+      "type": "group",
+      "description": "Approve a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName -n \"notes\" -i ENDEVOR",
+              "description": "Approve package with endevor profile set up, specifying approval notes"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The approve package command approves Package in Endevor for execution.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "notes",
+              "aliases": [
+                "n"
+              ],
+              "description": "Notes for package.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                60
+              ],
+              "conflictsWith": [
+                "notes-from-file"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "notes-from-file",
+              "aliases": [
+                "nff"
+              ],
+              "description": "Local file of notes for package.",
+              "type": "string",
+              "conflictsWith": [
+                "notes"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "backin",
+      "type": "group",
+      "description": "Backin a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName -i ENDEVOR",
+              "description": "Backin package with endevor profile set up"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The backin package command reverses the backout action and returns the Package to a status of Executed.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "statement",
+              "aliases": [
+                "stmn"
+              ],
+              "description": "Specify the SCL statement number for the Element action that you want to back in or back out.",
+              "type": "number",
+              "group": "options"
+            },
+            {
+              "name": "element",
+              "aliases": [
+                "elm"
+              ],
+              "description": "Specify the Element name for the Element action that you want to back in or back out.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "backout",
+      "type": "group",
+      "description": "Backout a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName -i ENDEVOR",
+              "description": "Backout package with endevor profile set up"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The backout package command restores the executable and output modules of the Package to the status they were in before execution.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "statement",
+              "aliases": [
+                "stmn"
+              ],
+              "description": "Specify the SCL statement number for the Element action that you want to back in or back out.",
+              "type": "number",
+              "group": "options"
+            },
+            {
+              "name": "element",
+              "aliases": [
+                "elm"
+              ],
+              "description": "Specify the Element name for the Element action that you want to back in or back out.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "cast",
+      "type": "group",
+      "description": "Cast a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName --fdt 2018-01-01T00:00 --tdt 2018-12-31T12:00 -i ENDEVOR",
+              "description": "Cast package with endevor profile set up, changing the execution window of the Package"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The cast package command prepares the Package for review and subsequent execution. Casting a Package freezes the contents of the Package and prevents further changes to the Package.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "from-date-time",
+              "aliases": [
+                "fdt"
+              ],
+              "description": "Specify the beginning of time frame within which the package can be executed. Use yyyy-mm-ddThh:mm or see ISO 8601 standard for syntax.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "to-date-time",
+              "aliases": [
+                "tdt"
+              ],
+              "description": "Specify the end of time frame within which the package can be executed. Use yyyy-mm-ddThh:mm or see ISO 8601 standard for syntax.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "validate-components",
+              "aliases": [
+                "vc"
+              ],
+              "description": "Specify \"yes\" to enable component validation within the package, \"no\" to disable, and \"warn\" to generate a warning if component validation fails.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "yes",
+                  "no",
+                  "warn"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "backout",
+              "description": "Set this option to false (or specify --no-backout) if you don't want to have the backout facility available for this package. By default backout is enabled.",
+              "type": "boolean",
+              "group": "options",
+              "defaultValue": true,
+              "aliases": []
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "commit",
+      "type": "group",
+      "description": "Commit a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName --delete-promotion-history -i ENDEVOR",
+              "description": "Commit package with endevor profile set up, specifying deletion of all promotion history"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The commit package command commits a Package, which removes all backout/backin data while retaining Package event information.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "older-than",
+              "aliases": [
+                "ot"
+              ],
+              "description": "Specify the minimum age of the package.",
+              "type": "number",
+              "group": "options"
+            },
+            {
+              "name": "delete-promotion-history",
+              "aliases": [
+                "dph"
+              ],
+              "description": "Specifies whether you want to delete all promotion history associated with previous versions of the Package",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "confirm",
+      "aliases": [
+        "conf"
+      ],
+      "type": "group",
+      "description": "Confirm a manual conflict resolution inside an Endevor workspace file is complete.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": " filename",
+              "description": "Confirm a manual conflict resolution has been finished for file 'filename'"
+            }
+          ],
+          "name": "resolution",
+          "aliases": [
+            "res"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "Confirm a manual conflict resolution inside an Endevor workspace file is complete.",
+          "positionals": [
+            {
+              "name": "workspace-file",
+              "description": "An Endevor workspace file (full or relative path).",
+              "type": "string"
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "create",
+      "type": "group",
+      "description": "Create a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName -d \"package description\" --ff localfile.txt -i ENDEVOR",
+              "description": "Create package from local file with endevor profile set up"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The create package command lets you create a package in Endevor.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "from-file",
+              "aliases": [
+                "ff"
+              ],
+              "description": "Use this input to provide source file.",
+              "type": "string",
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-package",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-dataset",
+              "aliases": [
+                "fd"
+              ],
+              "description": "Use this input to provide source data set name.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                44
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-member",
+              "aliases": [
+                "fm"
+              ],
+              "description": "Use this input to provide source member name in the data set.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-package",
+              "aliases": [
+                "fp"
+              ],
+              "description": "Directs the Create/Update action to copy the SCL from the package you specify into the package you are creating or updating.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                16
+              ],
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-text",
+              "aliases": [
+                "ft"
+              ],
+              "description": "Provides a string to use as input SCL.",
+              "type": "string",
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-dataset",
+                "from-member",
+                "from-uss-file"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "description",
+              "aliases": [
+                "d"
+              ],
+              "description": "Allows you to associate a 50-character description when creating or updating package.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                50
+              ],
+              "group": "options",
+              "required": true
+            },
+            {
+              "name": "from-date-time",
+              "aliases": [
+                "fdt"
+              ],
+              "description": "Specify the beginning of time frame within which the package can be executed. Use yyyy-mm-ddThh:mm or see ISO 8601 standard for syntax.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "to-date-time",
+              "aliases": [
+                "tdt"
+              ],
+              "description": "Specify the end of time frame within which the package can be executed. Use yyyy-mm-ddThh:mm or see ISO 8601 standard for syntax.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "backout",
+              "description": "Set this option to false (or specify --no-backout) if you don't want to have the backout facility available for this package. By default backout is enabled.",
+              "type": "boolean",
+              "group": "options",
+              "defaultValue": true,
+              "aliases": []
+            },
+            {
+              "name": "notes",
+              "aliases": [
+                "n"
+              ],
+              "description": "Notes for package.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                60
+              ],
+              "conflictsWith": [
+                "notes-from-file"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "notes-from-file",
+              "aliases": [
+                "nff"
+              ],
+              "description": "Local file of notes for package.",
+              "type": "string",
+              "conflictsWith": [
+                "notes"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "emergency-package",
+              "aliases": [
+                "ep"
+              ],
+              "description": "Specify if the package should be an emergency package. When not specified, the package is a standard package.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "sharable",
+              "aliases": [
+                "sh"
+              ],
+              "description": "Specify this option if the package can be edited by more than one person when in In-edit status.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "promotion",
+              "aliases": [
+                "pr"
+              ],
+              "description": "Specify this option to define the package as a promotion package.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "validate-scl",
+              "aliases": [
+                "vs"
+              ],
+              "description": "Set this option to false (or specify --no-validate-scl) to skip validion of the package components while creating a package. By default the SCL is validated",
+              "type": "boolean",
+              "group": "options",
+              "defaultValue": true
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "delete",
+      "aliases": [
+        "del"
+      ],
+      "type": "group",
+      "description": "Delete an Element or a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sn 1 --sys SYS --sub SUB --typ TYPE -i ENDEVOR",
+              "description": "Delete element with endevor profile set up"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The delete element command deletes an Element from the specified inventory location in Endevor.",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "proc-group",
+              "aliases": [
+                "pg"
+              ],
+              "description": "The Endevor processor group you would like to use.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "override-signout",
+              "aliases": [
+                "os"
+              ],
+              "description": "Specify if you want to override the Signout of an Endevor element while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "only-components",
+              "aliases": [
+                "oc"
+              ],
+              "description": "Applicable for Endevor ACM users only. Indicates whether you want to delete both the Element component list and the Element, or the Element component list only. \"No\" is the default option",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-all",
+              "aliases": [
+                "wca"
+              ],
+              "description": "Instructs Endevor to search both the Master Control File and the SOURCE DELTA levels for a specified CCIDs. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "packageName -i ENDEVOR",
+              "description": "Delete package with endevor profile set up"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The delete package command lets you delete Packages of any status type in Endevor.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "status",
+              "aliases": [
+                "st"
+              ],
+              "description": "Specify the status of the packages. Valid values are [APPROVED, EXECFAILED] for execute action, and additional values [INEDIT, INAPPROVAL, INEXECUTION, EXECUTED, COMMITTED, DENIED] for list action, additional value [ALLSTATE] for delete action. \nIt is possible to specify multiple status separated by \",\" during list and delete package.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "ALLSTATE",
+                  "INEDIT",
+                  "INAPPROVAL",
+                  "APPROVED",
+                  "INEXECUTION",
+                  "EXECUTED",
+                  "COMMITTED",
+                  "DENIED",
+                  "EXECFAILED"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "older-than",
+              "aliases": [
+                "ot"
+              ],
+              "description": "Specify the minimum age of the package.",
+              "type": "number",
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "deny",
+      "type": "group",
+      "description": "Deny a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName -n \"notes\" -i ENDEVOR",
+              "description": "Deny package with endevor profile set up, specifying denial notes"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The deny package command changes the status of a Package to Denied.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "notes",
+              "aliases": [
+                "n"
+              ],
+              "description": "Notes for package.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                60
+              ],
+              "conflictsWith": [
+                "notes-from-file"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "notes-from-file",
+              "aliases": [
+                "nff"
+              ],
+              "description": "Local file of notes for package.",
+              "type": "string",
+              "conflictsWith": [
+                "notes"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "execute",
+      "type": "group",
+      "description": "Execute a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName --fdt 2018-01-01T00:00 --tdt 2018-12-31T12:00 -i ENDEVOR",
+              "description": "Execute package with endevor profile set up, specifying the time frame within which to execute the Package"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The execute package command executes a Package that have a status of Approved or Execfailed.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "from-date-time",
+              "aliases": [
+                "fdt"
+              ],
+              "description": "Specify the beginning of time frame within which the package can be executed. Use yyyy-mm-ddThh:mm or see ISO 8601 standard for syntax.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "to-date-time",
+              "aliases": [
+                "tdt"
+              ],
+              "description": "Specify the end of time frame within which the package can be executed. Use yyyy-mm-ddThh:mm or see ISO 8601 standard for syntax.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "status",
+              "aliases": [
+                "st"
+              ],
+              "description": "Specify the status of the packages. Valid values are [APPROVED, EXECFAILED] for execute action, and additional values [INEDIT, INAPPROVAL, INEXECUTION, EXECUTED, COMMITTED, DENIED] for list action, additional value [ALLSTATE] for delete action. \nIt is possible to specify multiple status separated by \",\" during list and delete package.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "ALLSTATE",
+                  "INEDIT",
+                  "INAPPROVAL",
+                  "APPROVED",
+                  "INEXECUTION",
+                  "EXECUTED",
+                  "COMMITTED",
+                  "DENIED",
+                  "EXECFAILED"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "generate",
+      "aliases": [
+        "gen"
+      ],
+      "type": "group",
+      "description": "Generate an Element in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sn 1 --sys SYS --sub SUB --typ TYPE --cb -i ENDEVOR",
+              "description": "Generate an element with endevor profile set up, specifying option Copyback"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The generate element command executes the generate Processor for the current level of the Element.",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "proc-group",
+              "aliases": [
+                "pg"
+              ],
+              "description": "The Endevor processor group you would like to use.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "copy-back",
+              "aliases": [
+                "cb"
+              ],
+              "description": "Specify if you want to copy the current level of the Element back to the FROM Stage, then perform this action. Do not use with --nosource option.",
+              "type": "boolean",
+              "conflictsWith": [
+                "nosource"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "override-signout",
+              "aliases": [
+                "os"
+              ],
+              "description": "Specify if you want to override the Signout of an Endevor element while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "nosource",
+              "aliases": [
+                "ns"
+              ],
+              "description": "Specify if you want to have source-less Element. Do not use with --copy-back option.",
+              "type": "boolean",
+              "conflictsWith": [
+                "copy-back"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-all",
+              "aliases": [
+                "wca"
+              ],
+              "description": "Instructs Endevor to search both the Master Control File and the SOURCE DELTA levels for a specified CCIDs. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "initialize",
+      "aliases": [
+        "init"
+      ],
+      "type": "group",
+      "description": "Initialize a directory as an Endevor workspace.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "",
+              "description": "initialize current directory as an Endevor workspace"
+            },
+            {
+              "options": "'myWorkspace'",
+              "description": "initialize 'myWorkspace' directory as an Endevor workspace"
+            }
+          ],
+          "name": "workspace",
+          "aliases": [
+            "wsp"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "Initialize current directory as an Endevor workspace.",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "positionals": [
+            {
+              "name": "workspace-dir",
+              "description": "The Endevor workspace directory, if different from current working directory.",
+              "type": "string"
+            }
+          ],
+          "options": [
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port number of service on the mainframe.",
+              "type": "number",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates.",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "list",
+      "type": "group",
+      "description": "List instances, elements, types, packages and inventory locations in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "--host hostName --port 8080",
+              "description": "List instances with session specified"
+            }
+          ],
+          "name": "instances",
+          "aliases": [
+            "instance",
+            "inst",
+            "i"
+          ],
+          "description": "The list instances command lists instances used by Endevor Web Services",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "optional": [
+              "endevor",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "full-output",
+              "aliases": [
+                "fo"
+              ],
+              "description": "Specify this option if you want a full output of list action.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "User name to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Password to authenticate to service on the mainframe.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "-i ENDEVOR",
+              "description": "List all environments in Endevor with endevor profile set up"
+            }
+          ],
+          "name": "environments",
+          "aliases": [
+            "environment",
+            "env"
+          ],
+          "description": "The list environments command lists environments in Endevor",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "positionals": [
+            {
+              "name": "environment",
+              "type": "string",
+              "description": "Name of the Endevor environment.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                8
+              ]
+            }
+          ],
+          "options": [
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "path",
+              "aliases": [
+                "pa"
+              ],
+              "description": "Specifies a PHYsical or LOGical path.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "log",
+                  "phy"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "return",
+              "aliases": [
+                "ret"
+              ],
+              "description": "Sets mapping options for returned results: return FIRst match or ALL matching results.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "fir",
+                  "all"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "full-output",
+              "aliases": [
+                "fo"
+              ],
+              "description": "Specify this option if you want a full output of list action.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "-i ENDEVOR",
+              "description": "List all stages in Endevor with endevor profile set up"
+            }
+          ],
+          "name": "stages",
+          "aliases": [
+            "stage",
+            "stg"
+          ],
+          "description": "The list stages command lists stages in Endevor",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "positionals": [
+            {
+              "name": "stage",
+              "type": "string",
+              "description": "Name of the Endevor stage",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                8
+              ]
+            }
+          ],
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "path",
+              "aliases": [
+                "pa"
+              ],
+              "description": "Specifies a PHYsical or LOGical path.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "log",
+                  "phy"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "return",
+              "aliases": [
+                "ret"
+              ],
+              "description": "Sets mapping options for returned results: return FIRst match or ALL matching results.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "fir",
+                  "all"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "full-output",
+              "aliases": [
+                "fo"
+              ],
+              "description": "Specify this option if you want a full output of list action.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "-i ENDEVOR",
+              "description": "List all systems in Endevor with endevor profile set up"
+            }
+          ],
+          "name": "systems",
+          "aliases": [
+            "system",
+            "sys",
+            "s"
+          ],
+          "description": "The list systems command lists system information in Endevor",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "positionals": [
+            {
+              "name": "system",
+              "type": "string",
+              "description": "Name of the Endevor system",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                8
+              ]
+            }
+          ],
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "path",
+              "aliases": [
+                "pa"
+              ],
+              "description": "Specifies a PHYsical or LOGical path.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "log",
+                  "phy"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "return",
+              "aliases": [
+                "ret"
+              ],
+              "description": "Sets mapping options for returned results: return FIRst match or ALL matching results.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "fir",
+                  "all"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "full-output",
+              "aliases": [
+                "fo"
+              ],
+              "description": "Specify this option if you want a full output of list action.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "-i ENDEVOR",
+              "description": "List all subsystems in Endevor with endevor profile set up"
+            }
+          ],
+          "name": "subsystems",
+          "aliases": [
+            "subsystem",
+            "subsys",
+            "sbs"
+          ],
+          "description": "The list subsystems command lists subsystem information in Endevor",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "positionals": [
+            {
+              "name": "subsystem",
+              "type": "string",
+              "description": "Name of the Endevor subsystem",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                8
+              ]
+            }
+          ],
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "path",
+              "aliases": [
+                "pa"
+              ],
+              "description": "Specifies a PHYsical or LOGical path.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "log",
+                  "phy"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "return",
+              "aliases": [
+                "ret"
+              ],
+              "description": "Sets mapping options for returned results: return FIRst match or ALL matching results.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "fir",
+                  "all"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "full-output",
+              "aliases": [
+                "fo"
+              ],
+              "description": "Specify this option if you want a full output of list action.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "-i ENDEVOR",
+              "description": "List all types in Endevor with endevor profile set up"
+            }
+          ],
+          "name": "types",
+          "aliases": [
+            "type",
+            "t"
+          ],
+          "description": "The list types command lists type information in Endevor",
+          "type": "command",
+          "handler": "",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "positionals": [
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Name of the Endevor type",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                8
+              ]
+            }
+          ],
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "path",
+              "aliases": [
+                "pa"
+              ],
+              "description": "Specifies a PHYsical or LOGical path.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "log",
+                  "phy"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "return",
+              "aliases": [
+                "ret"
+              ],
+              "description": "Sets mapping options for returned results: return FIRst match or ALL matching results.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "fir",
+                  "all"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "full-output",
+              "aliases": [
+                "fo"
+              ],
+              "description": "Specify this option if you want a full output of list action.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "-i ENDEVOR",
+              "description": "List all packages in Endevor with endevor profile set up"
+            }
+          ],
+          "name": "packages",
+          "aliases": [
+            "package",
+            "pkg",
+            "p"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The list packages command lists package information in Endevor",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "status",
+              "aliases": [
+                "st"
+              ],
+              "description": "Specify the status of the packages. Valid values are [APPROVED, EXECFAILED] for execute action, and additional values [INEDIT, INAPPROVAL, INEXECUTION, EXECUTED, COMMITTED, DENIED] for list action, additional value [ALLSTATE] for delete action. \nIt is possible to specify multiple status separated by \",\" during list and delete package.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "ALLSTATE",
+                  "INEDIT",
+                  "INAPPROVAL",
+                  "APPROVED",
+                  "INEXECUTION",
+                  "EXECUTED",
+                  "COMMITTED",
+                  "DENIED",
+                  "EXECFAILED"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "emergency-package",
+              "aliases": [
+                "ep"
+              ],
+              "description": "Specify if the package should be an emergency package. When not specified, the package is a standard package.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "enterprise",
+              "aliases": [
+                "ent"
+              ],
+              "description": "Specify to filter the list by enterprise Package parameter. A - All, E - Enterprise, X - eXclude.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "A",
+                  "E",
+                  "X"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "promotion-status",
+              "aliases": [
+                "ps"
+              ],
+              "description": "Specify to filter the list by promotion Package parameter. A - All, P - Promotion, X - eXclude.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "A",
+                  "P",
+                  "X"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "prom-target-env",
+              "aliases": [
+                "pte"
+              ],
+              "description": "Promotion target environment. Specifies the promotion package target environment. This field only applies to promotion packages and can only be specified when the promotion package type is A or P.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "options"
+            },
+            {
+              "name": "prom-target-stgID",
+              "aliases": [
+                "pts"
+              ],
+              "description": "Promotion target stage ID. Specifies the promotion package target stage ID. This field only applies to promotion packages and can only be specified when the promotion package type is A or P.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "approver",
+              "aliases": [
+                "apr"
+              ],
+              "description": "Specifies a one to eight character approver ID. Only one approver ID can be specified and name masking is not supported. ",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "full-output",
+              "aliases": [
+                "fo"
+              ],
+              "description": "Specify this option if you want a full output of list action.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "-i ENDEVOR --env ENVNAME --sn 1 --sys SYSNAME --sub SUBNAME --typ TYPENAME",
+              "description": "List elements in Endevor from the specified inventory location with the endevor profile set up"
+            }
+          ],
+          "name": "elements",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The list elements command lists element information in Endevor",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "path",
+              "aliases": [
+                "pa"
+              ],
+              "description": "Specifies a PHYsical or LOGical path.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "log",
+                  "phy"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "return",
+              "aliases": [
+                "ret"
+              ],
+              "description": "Sets mapping options for returned results: return FIRst match or ALL matching results.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "fir",
+                  "all"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "data",
+              "aliases": [
+                "dat"
+              ],
+              "description": "Allows to select the type of summary data returned in the element list (defaults to all).",
+              "type": "string",
+              "defaultValue": "all",
+              "allowableValues": {
+                "values": [
+                  "all",
+                  "bas",
+                  "ele",
+                  "comp"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-retrieve",
+                "where-ccid-generate",
+                "where-ccid-lastact",
+                "where-ccid-lastlvl",
+                "where-ccid-change"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-generate",
+              "aliases": [
+                "wcg"
+              ],
+              "description": "Instructs Endevor to search using the generate CCID associated with an Element. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve",
+                "where-ccid-lastact",
+                "where-ccid-lastlvl",
+                "where-ccid-change"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-lastact",
+              "aliases": [
+                "wcla"
+              ],
+              "description": "Instructs Endevor to search using the last action CCID associated with an Element. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve",
+                "where-ccid-generate",
+                "where-ccid-lastlvl",
+                "where-ccid-change"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-lastlvl",
+              "aliases": [
+                "wcll"
+              ],
+              "description": "Instructs Endevor to search using the last level CCID associated with an Element. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve",
+                "where-ccid-generate",
+                "where-ccid-lastact",
+                "where-ccid-change"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-change",
+              "aliases": [
+                "wcchg"
+              ],
+              "description": "This option is only valid when the data option is ele or comp. Instructs Endevor to filter the results of the list data summary function that is based on the specified ccids. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve",
+                "where-ccid-generate",
+                "where-ccid-lastact",
+                "where-ccid-lastlvl"
+              ],
+              "implies": [
+                "data"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-generate",
+                "where-ccid-lastact",
+                "where-ccid-lastlvl",
+                "where-ccid-change"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-proc-type",
+              "aliases": [
+                "wpt"
+              ],
+              "description": "Lets you select Elements according to a specified Processor type.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "GEN",
+                  "GENERATE",
+                  "MOV",
+                  "MOVE",
+                  "DEL",
+                  "DELETE"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "to-package",
+              "aliases": [
+                "tp"
+              ],
+              "type": "string",
+              "description": "Specifies the package to which the SCL has to be appended. This option requires scl-action",
+              "required": false,
+              "implies": [
+                "scl-action"
+              ],
+              "stringLengthRange": [
+                1,
+                16
+              ],
+              "group": "scl generation options"
+            },
+            {
+              "name": "scl-action",
+              "aliases": [
+                "sa"
+              ],
+              "description": "Specifies the action for the SCL that has to be built.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "GENERATE",
+                  "MOVE"
+                ],
+                "caseSensitive": false
+              },
+              "implies": [
+                "to-package"
+              ],
+              "group": "scl generation options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "full-output",
+              "aliases": [
+                "fo"
+              ],
+              "description": "Specify this option if you want a full output of list action.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            },
+            {
+              "type": "command",
+              "name": "instances"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            },
+            {
+              "type": "command",
+              "name": "instances"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": {
+            "name": "full-output",
+            "aliases": [
+              "fo"
+            ],
+            "description": "Specify this option if you want a full output of list action.",
+            "type": "boolean",
+            "group": "output customization options"
+          },
+          "merge": true
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "merge",
+      "aliases": [
+        "mrg"
+      ],
+      "type": "group",
+      "description": "Merge Endevor elements from one Endevor location into another",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "ELEMENT1 --type COBPGM --subsystem SUBTO --merge-subsystem SUBFROM",
+              "description": "Merge element ELEMENT1 of type COBPGM from subsystem SUBFROM into the same element found in subsystem SUBTO (system, stage and env taken from current location profile)"
+            },
+            {
+              "options": "* --merge-out-of-sync",
+              "description": "Merge any elements that are currently out of sync with their next element version up the map (map location determined by current profile)"
+            },
+            {
+              "options": "* --merge-out-of-sync --dry-run",
+              "description": "Report which elements are currently out of sync with their next element version up the map, but do not merge them yet (map location determined by current profile)"
+            },
+            {
+              "options": "* --system SYSTO --subsystem SUBTO --merge-system SYSFROM --merge-subsystem SUBFROM",
+              "description": "Merge all elements from system SYSFROM, subsystem SUBFROM into matching elements in system SYSTO subsystem SUBTO (system, stage and env taken from current location profile)"
+            },
+            {
+              "options": "ELEMENT1 --type COBPGM --subsystem SUBTO --merge-subsystem SUBFROM --ccid MYCCID --comment 'my comment' --signout --overrride-signout",
+              "description": "Merge element ELEMENT1 of type COBPGM from subsystem SUBFROM into SUBTO, retrieving both elements using the provided ccid & comment, with signout, and overriding signout if necessary"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "Merge Endevor elements from one Endevor location into another. Requires an initialized Endevor workspace to perform conflict resolution. Use \"synchronize workspace\" command afterwards to push the result back into Endevor.",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "merge-environment",
+              "aliases": [
+                "menv"
+              ],
+              "type": "string",
+              "description": "Merge elements from this environment to the target environment (specified by 'environment'). Defaults to the same environment as the target.",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "group": "merge-location definition options"
+            },
+            {
+              "name": "merge-stage-number",
+              "aliases": [
+                "msn"
+              ],
+              "type": "string",
+              "description": "Merge elements from this stage number into the target stage number (specified by 'stage-number'). Defaults to the same stage number as the target.",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "group": "merge-location definition options"
+            },
+            {
+              "name": "merge-system",
+              "aliases": [
+                "msys"
+              ],
+              "type": "string",
+              "description": "Merge elements from this system into the target system (specified by 'system'). Defaults to the same system as the target.",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "group": "merge-location definition options"
+            },
+            {
+              "name": "merge-subsystem",
+              "aliases": [
+                "msub"
+              ],
+              "type": "string",
+              "description": "Merge elements from this subsystem into the target subsystem (specified by 'subsystem'). Defaults to the same subsystem as the target.",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "group": "merge-location definition options"
+            },
+            {
+              "name": "merge-out-of-sync",
+              "aliases": [
+                "moos"
+              ],
+              "type": "boolean",
+              "description": "Merge out-of-sync elements at the target location with their next version in the map, and attempt to resolve the out-of-sync during the next synchronization with Endevor.",
+              "conflictsWith": [
+                "merge-environment",
+                "merge-stage-number",
+                "merge-system",
+                "merge-subsystem"
+              ],
+              "group": "merge-location definition options"
+            },
+            {
+              "name": "workspace-dir",
+              "aliases": [
+                "wsp"
+              ],
+              "description": "The Endevor workspace directory, if different from current working directory.",
+              "defaultValue": ".",
+              "required": false,
+              "type": "string",
+              "group": "workspace options"
+            },
+            {
+              "name": "override-signout",
+              "aliases": [
+                "os"
+              ],
+              "description": "Specify if you want to override the Signout of any Endevor elements affected by this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "signout",
+              "description": "Specify if you want to perform the action with signing out any retrieved elements.",
+              "type": "boolean",
+              "group": "options",
+              "aliases": []
+            },
+            {
+              "name": "dry-run",
+              "aliases": [
+                "dr"
+              ],
+              "description": "List all actions the synchronization would perform, without executing them.",
+              "type": "boolean",
+              "group": "workspace options"
+            },
+            {
+              "name": "limit",
+              "aliases": [
+                "lim"
+              ],
+              "description": "If the synchronization would need to perform more than 'limit' Endevor actions, do not perform the actions now, only report them. 0 means no limit.",
+              "type": "number",
+              "defaultValue": 0,
+              "group": "workspace options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "move",
+      "aliases": [
+        "mv"
+      ],
+      "type": "group",
+      "description": "Move an Element in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sn 1 --sys SYS --sub SUB --typ TYPE -i ENDEVOR",
+              "description": "Move element from specified inventory location with endevor profile set up"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The move element command moves Elements between inventory locations along a map.",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "proc-group",
+              "aliases": [
+                "pg"
+              ],
+              "description": "The Endevor processor group you would like to use.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "sync",
+              "aliases": [
+                "s"
+              ],
+              "description": "Specify if you want to synchronize source and current level of the Elements while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "with-history",
+              "aliases": [
+                "wh"
+              ],
+              "description": "Specify if you want to preserve the change history of the Elements while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "bypass-element-delete",
+              "aliases": [
+                "bed"
+              ],
+              "description": "Specify if you want to retain the Elements in the source Stage after successfully completing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "retain-signout",
+              "aliases": [
+                "rs"
+              ],
+              "description": "Specify if you want to retain the source location signouts for all Elements at the target location while performing this action.",
+              "type": "boolean",
+              "conflictsWith": [
+                "signout-to"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "signout-to",
+              "aliases": [
+                "st"
+              ],
+              "description": "Specify if you want to sign all Elements out to the specified user ID at the target Stage while performing this action.",
+              "type": "string",
+              "conflictsWith": [
+                "retain-signout"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "jump",
+              "aliases": [
+                "j"
+              ],
+              "description": "Specify if you want to move Elements across Environments even if those Elements exist at an intermediate Stage that is not on the map, while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-all",
+              "aliases": [
+                "wca"
+              ],
+              "description": "Instructs Endevor to search both the Master Control File and the SOURCE DELTA levels for a specified CCIDs. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "print",
+      "aliases": [
+        "p"
+      ],
+      "type": "group",
+      "description": "Print an Element or a Component in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sn 1 --sys SYS --sub SUB --typ TYPE -i ENDEVOR",
+              "description": "Print element from specified inventory location with endevor profile set up"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "description": "The print element command prints selected information about Element in Endevor.",
+          "type": "command",
+          "handler": "",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "level",
+              "aliases": [
+                "lev"
+              ],
+              "description": "Indicates the level number of the element (use along with the version option).",
+              "type": "number",
+              "numericValueRange": [
+                0,
+                99
+              ],
+              "implies": [
+                "element-version"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "element-version",
+              "aliases": [
+                "ev"
+              ],
+              "description": "Indicates the version number of the element (use along with the level option).",
+              "type": "number",
+              "numericValueRange": [
+                1,
+                99
+              ],
+              "implies": [
+                "level"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "print",
+              "type": "string",
+              "description": "Specify the type of data to print out for print element command",
+              "required": false,
+              "defaultValue": "browse",
+              "allowableValues": {
+                "values": [
+                  "browse",
+                  "changes",
+                  "history",
+                  "summary",
+                  "master",
+                  "listing"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options",
+              "aliases": []
+            },
+            {
+              "name": "list-string",
+              "aliases": [
+                "ls"
+              ],
+              "type": "string",
+              "description": "Specifies the one to eight character text-string used to identify the listing data set to print.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "headings",
+              "type": "boolean",
+              "description": "Specify it if you want to print a header on each page.",
+              "required": false,
+              "group": "options",
+              "aliases": []
+            },
+            {
+              "name": "explode",
+              "aliases": [
+                "exp",
+                "ex"
+              ],
+              "type": "boolean",
+              "description": "Specify to print component info from ACMQ.",
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-all",
+              "aliases": [
+                "wca"
+              ],
+              "description": "Instructs Endevor to search both the Master Control File and the SOURCE DELTA levels for a specified CCIDs. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "to-file",
+              "aliases": [
+                "tf"
+              ],
+              "description": "The file name in which the data from the command output is stored",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sn 1 --sys SYS --sub SUB --typ TYPE -i ENDEVOR",
+              "description": "Print selected component information about Element with endevor profile set up"
+            }
+          ],
+          "name": "components",
+          "aliases": [
+            "comp"
+          ],
+          "description": "The print component command prints selected component information about Element in Endevor.",
+          "type": "command",
+          "handler": "",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "level",
+              "aliases": [
+                "lev"
+              ],
+              "description": "Indicates the level number of the element (use along with the version option).",
+              "type": "number",
+              "numericValueRange": [
+                0,
+                99
+              ],
+              "implies": [
+                "element-version"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "element-version",
+              "aliases": [
+                "ev"
+              ],
+              "description": "Indicates the version number of the element (use along with the level option).",
+              "type": "number",
+              "numericValueRange": [
+                1,
+                99
+              ],
+              "implies": [
+                "level"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "print-comp",
+              "aliases": [
+                "pc"
+              ],
+              "type": "string",
+              "description": "Specify the type of data to print out for print component command",
+              "required": false,
+              "defaultValue": "browse",
+              "allowableValues": {
+                "values": [
+                  "browse",
+                  "changes",
+                  "history",
+                  "summary"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "headings",
+              "type": "boolean",
+              "description": "Specify it if you want to print a header on each page.",
+              "required": false,
+              "group": "options",
+              "aliases": []
+            },
+            {
+              "name": "explode",
+              "aliases": [
+                "exp",
+                "ex"
+              ],
+              "type": "boolean",
+              "description": "Specify to print component info from ACMQ.",
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-all",
+              "aliases": [
+                "wca"
+              ],
+              "description": "Instructs Endevor to search both the Master Control File and the SOURCE DELTA levels for a specified CCIDs. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "to-file",
+              "aliases": [
+                "tf"
+              ],
+              "description": "The file name in which the data from the command output is stored",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "queryacm",
+      "type": "group",
+      "description": "Query Elements and information about their components in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENVNAME --sn 1 --sys SYSNAME --sub SUBNAME --typ TYPENAME -i ENDEVOR",
+              "description": "query all the components used by element \"elementName\" from the specified inventory location with the endevor profile set up"
+            }
+          ],
+          "name": "components",
+          "aliases": [
+            "comp"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "Query components used by a specified Element with the Endevor ACM Query facility.",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "excCirculars",
+              "aliases": [
+                "exc"
+              ],
+              "description": "Filters the result to exclude components that have a circular relationship to the subject of your search.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "excIndirect",
+              "aliases": [
+                "exi"
+              ],
+              "description": "Filters the result to exclude indirectly related components.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "excRelated",
+              "aliases": [
+                "exr"
+              ],
+              "description": "Filters the result to exclude related components.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "full-output",
+              "aliases": [
+                "fo"
+              ],
+              "description": "Specify this option if you want a full output of list action.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "reset",
+      "type": "group",
+      "description": "Reset a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName -i ENDEVOR",
+              "description": "Reset package with endevor profile set up"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The reset package command lets you set the status of a Package back to In-edit so you can modify it.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "retrieve",
+      "aliases": [
+        "ret"
+      ],
+      "type": "group",
+      "description": "Retrieve an Element in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENVNAME --sn 1 --sys SYSNAME --sub SUBNAME --typ TYPENAME --tf localfile.txt -i ENDEVOR",
+              "description": "Retrieve element from specified inventory location to local file with endevor profile set up"
+            },
+            {
+              "options": "\"*\" --env ENVNAME --sn 1 --sys SYSNAME --sub SUBNAME --typ \"*\" --to-dir /user/localdir -i ENDEVOR",
+              "description": "Bulk Retrieve elements with wildcarded element name and type, to local directory with endevor profile set up"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The retrieve element command retrieves an existing element in Endevor.",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "element-version",
+              "aliases": [
+                "ev"
+              ],
+              "description": "Indicates the version number of the element (use along with the level option).",
+              "type": "number",
+              "numericValueRange": [
+                1,
+                99
+              ],
+              "implies": [
+                "level"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "level",
+              "aliases": [
+                "lev"
+              ],
+              "description": "Indicates the level number of the element (use along with the version option).",
+              "type": "number",
+              "numericValueRange": [
+                0,
+                99
+              ],
+              "implies": [
+                "element-version"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "override-signout",
+              "aliases": [
+                "os"
+              ],
+              "description": "Specify if you want to override the Signout of an Endevor element while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "signout",
+              "description": "Specify if you want to perform the action with signing the element out.",
+              "type": "boolean",
+              "group": "options",
+              "aliases": []
+            },
+            {
+              "name": "replace-member",
+              "aliases": [
+                "replace",
+                "rm"
+              ],
+              "description": "Specify if you want to replace the member currently in the library with the new element contents",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "expand-includes",
+              "aliases": [
+                "expand",
+                "ei"
+              ],
+              "description": "Indicates that INCLUDE statements should be expanded in the course of the action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "get-fingerprint",
+              "aliases": [
+                "gfg"
+              ],
+              "description": "Return fingerprint of a retrieved, added or updated element as the first line of the response.",
+              "type": "boolean",
+              "defaultValue": false,
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-all",
+              "aliases": [
+                "wca"
+              ],
+              "description": "Instructs Endevor to search both the Master Control File and the SOURCE DELTA levels for a specified CCIDs. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "to-path",
+              "aliases": [
+                "tp"
+              ],
+              "description": "Provide a USS path to a destination location.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                768
+              ],
+              "conflictsWith": [
+                "to-dataset",
+                "to-member",
+                "to-file"
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "to-uss-file",
+              "aliases": [
+                "tuf"
+              ],
+              "description": "Provide a USS file as a destination file.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "conflictsWith": [
+                "to-dataset",
+                "to-member",
+                "to-file"
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "to-dataset",
+              "aliases": [
+                "td"
+              ],
+              "description": "Provide a destination data set name.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                44
+              ],
+              "conflictsWith": [
+                "to-path",
+                "to-uss-file",
+                "to-file"
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "to-member",
+              "aliases": [
+                "tm"
+              ],
+              "description": "Provide a destination member name inside the data set.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "conflictsWith": [
+                "to-path",
+                "to-uss-file",
+                "to-file"
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "to-file",
+              "aliases": [
+                "tf"
+              ],
+              "description": "The file name in which the data from the command output is stored",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "to-dir",
+              "aliases": [
+                "tdir"
+              ],
+              "description": "Directory name in which the command output will be stored.",
+              "type": "string",
+              "conflictsWith": [
+                "to-file",
+                "to-dataset",
+                "to-member",
+                "to-path",
+                "to-uss-file"
+              ],
+              "group": "bulk action options"
+            },
+            {
+              "name": "flat",
+              "description": " Store the output of the bulk action within one folder. When you use this option, ensure that the results do not contain duplicate names. (Duplicate names occur when two or more Elements have the same name and type.)",
+              "type": "boolean",
+              "implies": [
+                "to-dir"
+              ],
+              "group": "bulk action options",
+              "aliases": []
+            },
+            {
+              "name": "with-dependencies",
+              "aliases": [
+                "wd"
+              ],
+              "description": "Retrieve Elements, including their Endevor-managed input components.",
+              "type": "boolean",
+              "implies": [
+                "to-dir"
+              ],
+              "group": "bulk action options"
+            },
+            {
+              "name": "where-ccid-generate",
+              "aliases": [
+                "wcg"
+              ],
+              "description": "Instructs Endevor to search using the generate CCID associated with an Element. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current",
+                "where-ccid-retrieve",
+                "where-ccid-lastact",
+                "where-ccid-lastlvl",
+                "where-ccid-change"
+              ],
+              "group": "bulk action options",
+              "implies": [
+                "to-dir"
+              ]
+            },
+            {
+              "name": "where-ccid-lastact",
+              "aliases": [
+                "wcla"
+              ],
+              "description": "Instructs Endevor to search using the last action CCID associated with an Element. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current",
+                "where-ccid-retrieve",
+                "where-ccid-generate",
+                "where-ccid-lastlvl",
+                "where-ccid-change"
+              ],
+              "group": "bulk action options",
+              "implies": [
+                "to-dir"
+              ]
+            },
+            {
+              "name": "where-ccid-lastlvl",
+              "aliases": [
+                "wcll"
+              ],
+              "description": "Instructs Endevor to search using the last level CCID associated with an Element. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current",
+                "where-ccid-retrieve",
+                "where-ccid-generate",
+                "where-ccid-lastact",
+                "where-ccid-change"
+              ],
+              "group": "bulk action options",
+              "implies": [
+                "to-dir"
+              ]
+            },
+            {
+              "name": "where-ccid-change",
+              "aliases": [
+                "wcchg"
+              ],
+              "description": "This option is only valid when the data option is ele or comp. Instructs Endevor to filter the results of the list data summary function that is based on the specified ccids. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current",
+                "where-ccid-retrieve",
+                "where-ccid-generate",
+                "where-ccid-lastact",
+                "where-ccid-lastlvl"
+              ],
+              "implies": [
+                "to-dir"
+              ],
+              "group": "bulk action options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "outputFormatOptions": true,
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "signin",
+      "aliases": [
+        "si"
+      ],
+      "type": "group",
+      "description": "Signin an Element in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sn 1 --sys SYS --sub SUB --typ TYPE -i ENDEVOR",
+              "description": "Signin element with endevor profile set up"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The signin element command signs in an existing element in Endevor.",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "proc-group",
+              "aliases": [
+                "pg"
+              ],
+              "description": "The Endevor processor group you would like to use.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "override-signout",
+              "aliases": [
+                "os"
+              ],
+              "description": "Specify if you want to override the Signout of an Endevor element while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "signout-to",
+              "aliases": [
+                "st"
+              ],
+              "description": "Specify if you want to sign all Elements out to the specified user ID at the target Stage while performing this action.",
+              "type": "string",
+              "conflictsWith": [
+                "retain-signout"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-all",
+              "aliases": [
+                "wca"
+              ],
+              "description": "Instructs Endevor to search both the Master Control File and the SOURCE DELTA levels for a specified CCIDs. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "submit",
+      "type": "group",
+      "description": "Submit a Package or a SCL file in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName --ff jobcardfile.txt -i ENDEVOR",
+              "description": "Submit package using jobcard from local file, with endevor profile set up"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The submit package command submits a JCL job stream to execute one or more Packages.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "from-file",
+              "aliases": [
+                "ff"
+              ],
+              "description": "Use this input to provide source file.",
+              "type": "string",
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-package",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-dataset",
+              "aliases": [
+                "fd"
+              ],
+              "description": "Use this input to provide source data set name.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                44
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-member",
+              "aliases": [
+                "fm"
+              ],
+              "description": "Use this input to provide source member name in the data set.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "to-CA7",
+              "aliases": [
+                "t7"
+              ],
+              "description": "Specify to send the submission of the package to CA 7 scheduler.",
+              "type": "boolean",
+              "group": "output location options"
+            },
+            {
+              "name": "to-ddname",
+              "aliases": [
+                "tdd"
+              ],
+              "description": "Send the submission of the package to be processed according to a DDName specified in the starter task (STC).",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "status",
+              "aliases": [
+                "st"
+              ],
+              "description": "Specify the status of the packages. Valid values are [APPROVED, EXECFAILED] for execute action, and additional values [INEDIT, INAPPROVAL, INEXECUTION, EXECUTED, COMMITTED, DENIED] for list action, additional value [ALLSTATE] for delete action. \nIt is possible to specify multiple status separated by \",\" during list and delete package.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "ALLSTATE",
+                  "INEDIT",
+                  "INAPPROVAL",
+                  "APPROVED",
+                  "INEXECUTION",
+                  "EXECUTED",
+                  "COMMITTED",
+                  "DENIED",
+                  "EXECFAILED"
+                ],
+                "caseSensitive": false
+              },
+              "group": "options"
+            },
+            {
+              "name": "multiple-streams",
+              "aliases": [
+                "ms"
+              ],
+              "description": "Specify to submit a separate, unique job for each package. If you do not specify this, a single job with a unique job step for each package is submitted.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "increment-jobname",
+              "aliases": [
+                "ij"
+              ],
+              "description": "Specify to increases the last character in the jobcard you provide.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "jcl-procedure",
+              "aliases": [
+                "jp"
+              ],
+              "description": "This option lets you to identify the name of the JCL procedure that you want to invoke. ENDEVOR is used by default if any processor is specified.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "CA7-dependent-job",
+              "aliases": [
+                "7dj"
+              ],
+              "description": "Specifies a single predecessor job which must complete while demanded job is waiting in the CA 7 scheduler.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "--sf sclfile.txt --sclt element -i ENDEVOR",
+              "description": "Submit a SCL of type element, with endevor profile set up"
+            }
+          ],
+          "name": "scl",
+          "type": "command",
+          "handler": "",
+          "description": "The submit scl commands submits a SCL file to be executed.",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "scl-file",
+              "aliases": [
+                "sf",
+                "sclf"
+              ],
+              "description": "The file which contains the Endevor SCL you would like to submit.",
+              "type": "string",
+              "required": true,
+              "group": "options"
+            },
+            {
+              "name": "scl-type",
+              "aliases": [
+                "sclt"
+              ],
+              "description": "The category of Endevor SCL.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "list",
+                  "element",
+                  "package",
+                  "admin",
+                  "ship",
+                  "addUpdRtv"
+                ],
+                "caseSensitive": false
+              },
+              "required": true,
+              "group": "options"
+            },
+            {
+              "name": "from-file",
+              "aliases": [
+                "ff"
+              ],
+              "description": "Use this input to provide source file.",
+              "type": "string",
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-package",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "aliases": [],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "synchronize",
+      "aliases": [
+        "sync"
+      ],
+      "type": "group",
+      "description": "Synchronize remote Endevor inventory with the local Endevor workspace.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "",
+              "description": "Synchronize all elements in the map location defined by the currently active endevor-location profile with current directory"
+            },
+            {
+              "options": "'C:/projects/myWorkspace'",
+              "description": "Synchronize all elements in the map location defined by the currently active endevor-location profile with workspace directory 'C:/projects/myWorkspace'"
+            },
+            {
+              "options": "--environment DEV --stage_number 1 --system SYSTEM1 --subsystem SUBSYS1 --type ASM* --ccid myccid --comment 'my changes'",
+              "description": "Synchronize all elements in system SYSTEM1 subsystem SUBSYS1 from environment DEV stage 1, whose type begins with 'ASM', with current directory"
+            },
+            {
+              "options": "'C:/projects/myWorkspace' --ccid myccid --comment 'my changes' --element PRFX%%11",
+              "description": "Synchronize all elements in the map location defined by the currently active endevor-location profile, whose name is 'PRFX' followed by any 2 characters and ending with '11', with workspace directory 'C:/projects/myWorkspace'"
+            },
+            {
+              "options": "--dry-run --endevor-location-profile mysandbox",
+              "description": "Display all actions needed to synchronize all elements in the map location defined by endevor-location profile 'mysandbox' with current directory, without performing them"
+            },
+            {
+              "options": "--reset",
+              "description": "Revert all local changes in the map location defined by the currently active endevor-location profile, resetting your workspace to match Endevor"
+            }
+          ],
+          "name": "workspace",
+          "aliases": [
+            "wsp"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "Synchronize a selected subset of remote Endevor inventory with a local Endevor workspace",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "positionals": [
+            {
+              "name": "workspace-dir",
+              "description": "The Endevor workspace directory, if different from current working directory.",
+              "type": "string"
+            }
+          ],
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "override-signout",
+              "aliases": [
+                "os"
+              ],
+              "description": "Specify if you want to override the Signout of any Endevor elements affected by this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "signout",
+              "description": "Specify if you want to perform the action with signing out any retrieved elements.",
+              "type": "boolean",
+              "group": "options",
+              "aliases": []
+            },
+            {
+              "name": "element",
+              "aliases": [
+                "ele",
+                "elem"
+              ],
+              "type": "string",
+              "description": "Name filter to synchronize only specific Endevor element(s).",
+              "defaultValue": "*",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "group": "workspace options"
+            },
+            {
+              "name": "dry-run",
+              "aliases": [
+                "dr"
+              ],
+              "description": "List all actions the synchronization would perform, without executing them.",
+              "type": "boolean",
+              "group": "workspace options"
+            },
+            {
+              "name": "reset",
+              "aliases": [
+                "rst"
+              ],
+              "description": "Revert any local changes, resetting the local workspace to match the current state of the remote Endevor inventory.",
+              "type": "boolean",
+              "group": "workspace options"
+            },
+            {
+              "name": "limit",
+              "aliases": [
+                "lim"
+              ],
+              "description": "If the synchronization would need to perform more than 'limit' Endevor actions, do not perform the actions now, only report them. 0 means no limit.",
+              "type": "number",
+              "defaultValue": 0,
+              "group": "workspace options"
+            },
+            {
+              "name": "one-way",
+              "aliases": [],
+              "description": "Do not update Endevor elements with local changes, only retrieve remote changes from Endevor and resolve any conflicts.",
+              "type": "boolean",
+              "group": "workspace options"
+            },
+            {
+              "name": "allow-deletes",
+              "aliases": [
+                "del"
+              ],
+              "description": "Allow workspace synchronization to delete unchanged Endevor elements when it detects the corresponding local files have been deleted. Default is off to maintain backward compatibility.",
+              "type": "boolean",
+              "group": "workspace options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "transfer",
+      "aliases": [
+        "tr"
+      ],
+      "type": "group",
+      "description": "Transfer an Element in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sn 1 --tosn 2 --sys SYS --sub SUB --typ TYPE -i ENDEVOR",
+              "description": "Transfer element from specified inventory location to 1 stage higher in map, with endevor profile set up"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The Transfer element command transfers Elements from one Endevor location to another.",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "to-environment",
+              "aliases": [
+                "toenv"
+              ],
+              "description": "The target Endevor environment.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "to-system",
+              "aliases": [
+                "tosys"
+              ],
+              "description": "The target Endevor system.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "to-subsystem",
+              "aliases": [
+                "tosub"
+              ],
+              "description": "The target Endevor subsystem.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "to-element",
+              "aliases": [
+                "toele"
+              ],
+              "description": "The target Endevor element name.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "to-type",
+              "aliases": [
+                "totyp"
+              ],
+              "description": "The target Endevor element type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "to-stage-number",
+              "aliases": [
+                "tosn"
+              ],
+              "description": "The target Endevor stage Id/number.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                1
+              ],
+              "group": "output location options"
+            },
+            {
+              "name": "proc-group",
+              "aliases": [
+                "pg"
+              ],
+              "description": "The Endevor processor group you would like to use.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "element-version",
+              "aliases": [
+                "ev"
+              ],
+              "description": "Indicates the version number of the element (use along with the level option).",
+              "type": "number",
+              "numericValueRange": [
+                1,
+                99
+              ],
+              "implies": [
+                "level"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "level",
+              "aliases": [
+                "lev"
+              ],
+              "description": "Indicates the level number of the element (use along with the version option).",
+              "type": "number",
+              "numericValueRange": [
+                0,
+                99
+              ],
+              "implies": [
+                "element-version"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "new-version",
+              "aliases": [
+                "nv"
+              ],
+              "description": "Assign a different version number to the Element.",
+              "type": "number",
+              "numericValueRange": [
+                1,
+                99
+              ],
+              "group": "options"
+            },
+            {
+              "name": "sync",
+              "aliases": [
+                "s"
+              ],
+              "description": "Specify if you want to synchronize source and current level of the Elements while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "with-history",
+              "aliases": [
+                "wh"
+              ],
+              "description": "Specify if you want to preserve the change history of the Elements while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "ignore-generate-failed",
+              "aliases": [
+                "igf"
+              ],
+              "description": "Process the transfer request regardless of whether the FAILED flag is set for the element or if the element was generated or moved successfully.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "bypass-element-delete",
+              "aliases": [
+                "bed"
+              ],
+              "description": "Specify if you want to retain the Elements in the source Stage after successfully completing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "bypass-delete-proc",
+              "aliases": [
+                "bdp"
+              ],
+              "description": "Specity to bypasses the execution of the delete processor.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "bypass-generate-proc",
+              "aliases": [
+                "bgp"
+              ],
+              "description": "Specify to bypasses the execution of the generate or move processor (whichever may be chosen) upon element transfer.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "retain-signout",
+              "aliases": [
+                "rs"
+              ],
+              "description": "Specify if you want to retain the source location signouts for all Elements at the target location while performing this action.",
+              "type": "boolean",
+              "conflictsWith": [
+                "signout-to"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "signout-to",
+              "aliases": [
+                "st"
+              ],
+              "description": "Specify if you want to sign all Elements out to the specified user ID at the target Stage while performing this action.",
+              "type": "string",
+              "conflictsWith": [
+                "retain-signout"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "override-signout",
+              "aliases": [
+                "os"
+              ],
+              "description": "Specify if you want to override the Signout of an Endevor element while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-all",
+              "aliases": [
+                "wca"
+              ],
+              "description": "Instructs Endevor to search both the Master Control File and the SOURCE DELTA levels for a specified CCIDs. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "unsynchronize",
+      "aliases": [
+        "unsync"
+      ],
+      "type": "group",
+      "description": "Remove a synchronized Endevor inventory from a local Endevor workspace and delete any related metadata.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "",
+              "description": "Remove all elements in the map location defined by the currently active endevor-location profile from current directory"
+            },
+            {
+              "options": "--force",
+              "description": "Remove all elements in the map location defined by the currently active endevor-location profile from current directory, throwing away any local changes not saved in Endevor"
+            },
+            {
+              "options": "'C:/projects/myWorkspace'",
+              "description": "Remove all elements in the map location defined by the currently active endevor-location profile from workspace directory 'C:/projects/myWorkspace'"
+            },
+            {
+              "options": "--environment DEV --stage_number 1 --system SYSTEM1 --subsystem SUBSYS1 --type ASM* --ccid myccid --comment 'my changes'",
+              "description": "Remove all elements in system SYSTEM1 subsystem SUBSYS1 environment DEV stage 1, whose type begins with 'ASM', from current directory"
+            }
+          ],
+          "name": "workspace",
+          "aliases": [
+            "wsp"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "Remove a selected subset of remote Endevor inventory from a local Endevor workspace",
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "positionals": [
+            {
+              "name": "workspace-dir",
+              "description": "The Endevor workspace directory, if different from current working directory.",
+              "type": "string"
+            }
+          ],
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "\\*",
+                  "\\%",
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "element",
+              "aliases": [
+                "ele",
+                "elem"
+              ],
+              "type": "string",
+              "description": "Name filter to synchronize only specific Endevor element(s).",
+              "defaultValue": "*",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "group": "workspace options"
+            },
+            {
+              "name": "force",
+              "aliases": [
+                "f"
+              ],
+              "description": "Force unsynchronization of local workspace regardless of any local changes not yet saved into Endevor.",
+              "type": "boolean",
+              "group": "workspace options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "update",
+      "type": "group",
+      "description": "Update an Element or a Package in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "packageName --ff localfile.txt -i ENDEVOR",
+              "description": "Update package from local file with endevor profile set up"
+            }
+          ],
+          "name": "package",
+          "aliases": [
+            "pkg"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The update package command lets you update a package in Endevor.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "from-file",
+              "aliases": [
+                "ff"
+              ],
+              "description": "Use this input to provide source file.",
+              "type": "string",
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-package",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-dataset",
+              "aliases": [
+                "fd"
+              ],
+              "description": "Use this input to provide source data set name.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                44
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-member",
+              "aliases": [
+                "fm"
+              ],
+              "description": "Use this input to provide source member name in the data set.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-package",
+              "aliases": [
+                "fp"
+              ],
+              "description": "Directs the Create/Update action to copy the SCL from the package you specify into the package you are creating or updating.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                16
+              ],
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-text",
+              "aliases": [
+                "ft"
+              ],
+              "description": "Provides a string to use as input SCL.",
+              "type": "string",
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-dataset",
+                "from-member",
+                "from-uss-file"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "description",
+              "aliases": [
+                "d"
+              ],
+              "description": "Allows you to associate a 50-character description when creating or updating package.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                50
+              ],
+              "group": "options"
+            },
+            {
+              "name": "from-date-time",
+              "aliases": [
+                "fdt"
+              ],
+              "description": "Specify the beginning of time frame within which the package can be executed. Use yyyy-mm-ddThh:mm or see ISO 8601 standard for syntax.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "to-date-time",
+              "aliases": [
+                "tdt"
+              ],
+              "description": "Specify the end of time frame within which the package can be executed. Use yyyy-mm-ddThh:mm or see ISO 8601 standard for syntax.",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "backout",
+              "description": "Set this option to false (or specify --no-backout) if you don't want to have the backout facility available for this package. By default backout is enabled.",
+              "type": "boolean",
+              "group": "options",
+              "defaultValue": true,
+              "aliases": []
+            },
+            {
+              "name": "notes",
+              "aliases": [
+                "n"
+              ],
+              "description": "Notes for package.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                60
+              ],
+              "conflictsWith": [
+                "notes-from-file"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "notes-from-file",
+              "aliases": [
+                "nff"
+              ],
+              "description": "Local file of notes for package.",
+              "type": "string",
+              "conflictsWith": [
+                "notes"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "emergency-package",
+              "aliases": [
+                "ep"
+              ],
+              "description": "Specify if the package should be an emergency package. When not specified, the package is a standard package.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "sharable",
+              "aliases": [
+                "sh"
+              ],
+              "description": "Specify this option if the package can be edited by more than one person when in In-edit status.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "promotion",
+              "aliases": [
+                "pr"
+              ],
+              "description": "Specify this option to define the package as a promotion package.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "validate-scl",
+              "aliases": [
+                "vs"
+              ],
+              "description": "Set this option to false (or specify --no-validate-scl) to skip validion of the package components while creating a package. By default the SCL is validated",
+              "type": "boolean",
+              "group": "options",
+              "defaultValue": true
+            },
+            {
+              "name": "append",
+              "aliases": [
+                "a"
+              ],
+              "description": "Specify this option to append the SCL you are adding to the existing package SCL. Otherwise it would be replaced.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sys SYS --sub SUB --typ TYPE --ff localfile.txt -i ENDEVOR",
+              "description": "Update element from local file with endevor profile set up"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The update element command updates an Element in the entry Stage, thereby creating a new level for the Element in the entry Stage. ",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "from-file",
+              "aliases": [
+                "ff"
+              ],
+              "description": "Use this input to provide source file.",
+              "type": "string",
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-package",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-dataset",
+              "aliases": [
+                "fd"
+              ],
+              "description": "Use this input to provide source data set name.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                44
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-member",
+              "aliases": [
+                "fm"
+              ],
+              "description": "Use this input to provide source member name in the data set.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-path",
+                "from-uss-file",
+                "from-text"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-path",
+              "aliases": [
+                "fp"
+              ],
+              "description": "Use this input to provide the path of source USS file. It must be used with from-uss-file.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                768
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-dataset",
+                "from-member",
+                "from-text"
+              ],
+              "implies": [
+                "from-uss-file"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "from-uss-file",
+              "aliases": [
+                "fuf"
+              ],
+              "description": "Use this input to provide source USS file name. It must be used with from-path",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                255
+              ],
+              "conflictsWith": [
+                "from-package",
+                "from-file",
+                "from-dataset",
+                "from-member",
+                "from-text"
+              ],
+              "implies": [
+                "from-path"
+              ],
+              "group": "input sources options"
+            },
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "override-signout",
+              "aliases": [
+                "os"
+              ],
+              "description": "Specify if you want to override the Signout of an Endevor element while performing this action.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "proc-group",
+              "aliases": [
+                "pg"
+              ],
+              "description": "The Endevor processor group you would like to use.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "generate",
+              "aliases": [
+                "g"
+              ],
+              "description": "Specifies if you want to Generate Element after Add/Update action.",
+              "type": "boolean",
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "get-fingerprint",
+              "aliases": [
+                "gfg"
+              ],
+              "description": "Return fingerprint of a retrieved, added or updated element as the first line of the response.",
+              "type": "boolean",
+              "defaultValue": false,
+              "group": "options"
+            },
+            {
+              "name": "fingerprint",
+              "aliases": [
+                "fg"
+              ],
+              "description": "Specifies the fingerprint of the element to Add or Update. Use value 'NEW' when adding a new element that shouldn't exist in the map yet.",
+              "type": "string",
+              "conflictsWith": [
+                "from-dataset",
+                "from-member",
+                "from-path",
+                "from-uss-file"
+              ],
+              "required": false,
+              "group": "options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    },
+    {
+      "name": "view",
+      "type": "group",
+      "description": "View an Element or a Package SCL in Endevor.",
+      "children": [
+        {
+          "examples": [
+            {
+              "options": "elementName --env ENV --sn 1 --sys SYS --sub SUB --typ TYPE --tf localfile.txt -i ENDEVOR",
+              "description": "View element from specified inventory location to local file with endevor profile set up"
+            }
+          ],
+          "name": "element",
+          "aliases": [
+            "elem",
+            "ele"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The view element command views an existing element in Endevor.",
+          "positionals": [
+            {
+              "name": "element",
+              "type": "string",
+              "description": "Name of the Endevor element.",
+              "required": true,
+              "stringLengthRange": [
+                1,
+                255
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "environment",
+              "aliases": [
+                "env"
+              ],
+              "description": "The Endevor environment where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "system",
+              "aliases": [
+                "sys"
+              ],
+              "description": "The Endevor system where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "subsystem",
+              "aliases": [
+                "sub"
+              ],
+              "description": "The Endevor subsystem where your project resides.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "type",
+              "aliases": [
+                "typ"
+              ],
+              "description": "Name of the Endevor element's type.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                8
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "stage-number",
+              "aliases": [
+                "sn"
+              ],
+              "description": "The Endevor stage number where your project resides.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "1",
+                  "2"
+                ]
+              },
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "ccid",
+              "aliases": [
+                "cci"
+              ],
+              "description": "The CCID you want to use when performing an Element action.",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                12
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "comment",
+              "aliases": [
+                "com"
+              ],
+              "description": "The comment you want to have when performing an Element action",
+              "type": "string",
+              "stringLengthRange": [
+                1,
+                40
+              ],
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "element-version",
+              "aliases": [
+                "ev"
+              ],
+              "description": "Indicates the version number of the element (use along with the level option).",
+              "type": "number",
+              "numericValueRange": [
+                1,
+                99
+              ],
+              "implies": [
+                "level"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "level",
+              "aliases": [
+                "lev"
+              ],
+              "description": "Indicates the level number of the element (use along with the version option).",
+              "type": "number",
+              "numericValueRange": [
+                0,
+                99
+              ],
+              "implies": [
+                "element-version"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "search",
+              "aliases": [
+                "sea"
+              ],
+              "description": "Enables the search through the Endevor map.",
+              "type": "boolean",
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-all",
+              "aliases": [
+                "wca"
+              ],
+              "description": "Instructs Endevor to search both the Master Control File and the SOURCE DELTA levels for a specified CCIDs. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-current",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-current",
+              "aliases": [
+                "wcc"
+              ],
+              "description": "Instructs Endevor to search through the CCID fields in the Master Control File to find a specified CCIDs. \nAccept up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-retrieve"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-ccid-retrieve",
+              "aliases": [
+                "wcr"
+              ],
+              "description": "Instructs Endevor to use the CCID in the Master Control File RETRIEVE CCID field. \nAccepts up to 8 CCIDs separated by \", \". Enclose CCIDs that contain special characters in quotes.",
+              "type": "string",
+              "conflictsWith": [
+                "where-ccid-all",
+                "where-ccid-current"
+              ],
+              "group": "options"
+            },
+            {
+              "name": "where-proc-group",
+              "aliases": [
+                "wpg"
+              ],
+              "description": "Lets you select Elements according to a specified Processor group. You can use a wildcard when specifying the Processor group name. \nAccepts up to 8 Processor group names separated by \", \". ",
+              "type": "string",
+              "group": "options"
+            },
+            {
+              "name": "to-file",
+              "aliases": [
+                "tf"
+              ],
+              "description": "The file name in which the data from the command output is stored",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "examples": [
+            {
+              "options": "packageName -i ENDEVOR",
+              "description": "View SCL of package \"packageName\" in the console with endevor profile set up"
+            }
+          ],
+          "name": "pkgscl",
+          "aliases": [
+            "packagescl"
+          ],
+          "type": "command",
+          "handler": "",
+          "description": "The view pkgscl command views the SCL of an existing package in Endevor.",
+          "positionals": [
+            {
+              "name": "package",
+              "type": "string",
+              "description": "Name of the Endevor package.",
+              "required": false,
+              "stringLengthRange": [
+                1,
+                16
+              ]
+            }
+          ],
+          "profile": {
+            "optional": [
+              "endevor",
+              "endevor-location",
+              "base"
+            ]
+          },
+          "options": [
+            {
+              "name": "maxrc",
+              "description": "The maximum value of the return code of a successful action. When the return code is greater than the maxrc value, the command fails",
+              "type": "number",
+              "defaultValue": 8,
+              "group": "endevor-location definition options",
+              "aliases": []
+            },
+            {
+              "name": "to-file",
+              "aliases": [
+                "tf"
+              ],
+              "description": "The file name in which the data from the command output is stored",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-examples",
+              "group": "Global options",
+              "description": "Display examples for all the commands in a group",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "endevor-profile",
+              "aliases": [
+                "endevor-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "endevor-location-profile",
+              "aliases": [
+                "endevor-location-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (endevor-location) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            }
+          ],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "host",
+              "aliases": [
+                "hostname"
+              ],
+              "description": "Specifies the base host name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "p"
+              ],
+              "description": "Specifies the port number.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "instance",
+              "aliases": [
+                "i"
+              ],
+              "description": "Specifies Endevor Web Services dataSource name.",
+              "type": "string",
+              "group": "endevor-location definition options"
+            },
+            {
+              "name": "protocol",
+              "aliases": [
+                "prot"
+              ],
+              "description": "Specifies the protocol used for connecting to Endevor Rest API",
+              "type": "string",
+              "defaultValue": "https",
+              "allowableValues": {
+                "values": [
+                  "http",
+                  "https"
+                ],
+                "caseSensitive": false
+              },
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "username"
+              ],
+              "description": "Specifies the user name.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass"
+              ],
+              "description": "Specifies the user's password.",
+              "type": "string",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Specify this option to have the server certificate verified against the list of supplied CAs",
+              "type": "boolean",
+              "group": "endevor session definition options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "Specifies the base path used for connecting to Endevor Rest API",
+              "type": "string",
+              "group": "endevor session definition options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        },
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "suppress-messages",
+              "aliases": [
+                "sm"
+              ],
+              "description": "Suppress all [INFO]/[WARN] messages from terminal output.",
+              "type": "boolean",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-file",
+              "aliases": [
+                "file-name"
+              ],
+              "description": "File name for saving reports from Endevor SCM locally.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "report-dir",
+              "description": "Directory for saving reports from Endevor SCM locally, if --report-file wasn't specified. Defaults to current directory.",
+              "type": "string",
+              "group": "output customization options"
+            },
+            {
+              "name": "write-report",
+              "description": "Write the endevor reports to a file. By default, when return code is 0, no report will be written, unless this option is specified. When return code is bigger than 0, reports will be written to a file, unless this option is specifed to be false",
+              "type": "boolean",
+              "group": "output customization options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-examples",
+          "group": "Global options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "aliases": [],
+      "positionals": []
+    }
+  ],
+  "options": [
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "aliases": [],
+  "positionals": [],
+  "passOn": []
+}

--- a/profiles/create/dbm-db2.jsonc
+++ b/profiles/create/dbm-db2.jsonc
@@ -1,0 +1,257 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "dbm-db2-profile",
+  "aliases": [
+    "dbm-db2"
+  ],
+  "summary": "Create a dbm-db2 profile",
+  "description": "The dbm-db2 profile is a named set of DBM Data Service parameters that are implicitly used with the zowe dbm-db2 commands. The profile includes server connection, z/OS execution, and user-dependent details.",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config init' command",
+  "customize": {
+    "profileTypeIdentifier": "dbm-db2"
+  },
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the new dbm-db2 profile. You can load this profile by using the name on commands that support the \"--dbm-db2-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "options": [
+    {
+      "name": "job-cards",
+      "aliases": [
+        "jc"
+      ],
+      "description": "Specifies a string array of z/OS JCL JOB statements.",
+      "required": false,
+      "type": "array",
+      "defaultValue": [
+        "//DB2DVOPS CLASS=A,",
+        "//         MSGCLASS=X"
+      ],
+      "group": "dbm-db2 Common Options"
+    },
+    {
+      "name": "work-dataset-prefix",
+      "aliases": [
+        "wdp"
+      ],
+      "description": "Specifies the prefix that is used as the high level qualifier in z/OS work data set names.",
+      "required": false,
+      "type": "string",
+      "defaultValue": "${user}.dbmdb2",
+      "group": "dbm-db2 Common Options"
+    },
+    {
+      "name": "authid",
+      "aliases": [
+        "a"
+      ],
+      "description": "Specifies the primary Db2 authorization ID (user ID) that is used to establish a connection between Db2 and a process.",
+      "required": false,
+      "type": "string",
+      "defaultValue": "${user}",
+      "group": "dbm-db2 Common Options"
+    },
+    {
+      "name": "sqlid",
+      "aliases": [
+        "s"
+      ],
+      "description": "Specifies the authorization ID that is used as the value in generated SET CURRENT SQLID statements most of the time.",
+      "required": false,
+      "type": "string",
+      "defaultValue": "${user}",
+      "group": "dbm-db2 Common Options"
+    },
+    {
+      "name": "termination-character",
+      "aliases": [
+        "tc"
+      ],
+      "description": "Specifies the SQL termination character that you want to use to terminate object DDL for triggers, XML indexes, functions, and procedures that contain embedded semicolon-terminated SQL statements. You cannot use a comma, an underscore, a single quote, double quotes, left parentheses, or right parentheses for this value.",
+      "required": false,
+      "type": "string",
+      "defaultValue": ";",
+      "stringLengthRange": [
+        1,
+        1
+      ],
+      "group": "dbm-db2 Common Options"
+    },
+    {
+      "name": "overwrite-output-files",
+      "aliases": [
+        "oof"
+      ],
+      "description": "Specifies whether to overwrite output files when they already exist.",
+      "required": false,
+      "type": "boolean",
+      "defaultValue": false,
+      "group": "dbm-db2 Common Options"
+    },
+    {
+      "name": "host",
+      "aliases": [
+        "H"
+      ],
+      "description": "Specifies the DBM Data Service REST API server host name or TCP/IP address to use.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Connection Options"
+    },
+    {
+      "name": "port",
+      "aliases": [
+        "P"
+      ],
+      "description": "Specifies the DBM Data Service REST API server TCP/IP port number.",
+      "required": false,
+      "type": "number",
+      "defaultValue": 7300,
+      "group": "dbm-db2 Connection Options"
+    },
+    {
+      "name": "user",
+      "aliases": [
+        "u"
+      ],
+      "description": "Specifies the mainframe user name that you want to use to connect to the mainframe systems during execution of the Zowe CLI commands. This user name can be the same as your TSO login ID.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Connection Options"
+    },
+    {
+      "name": "password",
+      "aliases": [
+        "pass",
+        "pw"
+      ],
+      "description": "Specifies the mainframe password for the user name that is used to connect to the mainframe systems during execution of the CLI commands. This password can be the same as your TSO password.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Connection Options"
+    },
+    {
+      "name": "reject-unauthorized",
+      "aliases": [
+        "ru"
+      ],
+      "description": "Determines whether the dbm-db2 command is accepted or rejected when a self-signed certificate is returned by the DBM Data Service.",
+      "required": false,
+      "type": "boolean",
+      "defaultValue": true,
+      "group": "dbm-db2 Connection Options"
+    },
+    {
+      "name": "protocol",
+      "description": "Specifies the communication protocol to use between the zowe dbm-db2 client and the DBM Data Service.",
+      "required": false,
+      "type": "string",
+      "defaultValue": "https",
+      "allowableValues": {
+        "values": [
+          "http",
+          "https"
+        ]
+      },
+      "group": "dbm-db2 Connection Options",
+      "aliases": []
+    },
+    {
+      "name": "environment-list",
+      "aliases": [
+        "el"
+      ],
+      "description": "Specifies an object of one or more values consisting of a Db2 subsystem ID and a DBM Data Service environment pair. The paired entry identifies the DBM Data Service environment to use for a subsystem that is accessible through multiple DBM Data Service environments. For more information about configuring the DBM Data Service, see the Database Management Solutions for Db2 for z/OS documentation at https://techdocs.broadcom.com/db2mgmt.",
+      "required": false,
+      "type": "string",
+      "defaultValue": {
+        "ssid1": "env1@host1:port1",
+        "ssid2": "env2@host2:port2"
+      },
+      "group": "dbm-db2 Connection Options"
+    },
+    {
+      "name": "overwrite",
+      "aliases": [
+        "ow"
+      ],
+      "description": "Overwrite the dbm-db2 profile when a profile of the same name exists.",
+      "type": "boolean",
+      "group": "Options"
+    },
+    {
+      "name": "disable-defaults",
+      "aliases": [
+        "dd"
+      ],
+      "description": "Disable populating profile values of undefined properties with default values.",
+      "type": "boolean",
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "examples": [
+    {
+      "options": "profile_name1",
+      "description": "Create a dbm-db2 profile named profile_name1 and default values for all the dbm-db2-profile options"
+    },
+    {
+      "options": "dbm123 --host dbm123 --port 1443 --user db2user --password myp4ss",
+      "description": "Create a dbm-db2 profile named dbm123 that connects to the DBM Data Service at host dbm123 and port 1443 as user db2user and password myp4ss"
+    },
+    {
+      "options": "dbm124 --host dbm124 --user db2user --password myp4ss --reject-unauthorized false",
+      "description": "Create a dbm-db2 profile named dbm124 that connects to the DBM Data Service at host dbm124 and the default port as user db2user and password myp4ss, and allow self-signed certificates"
+    },
+    {
+      "options": "dbm125 --host dbm125 --port 1443 --environment-list \"SUBA:prod@host1.com:322,SUBB:test@host2.net:522\"",
+      "description": "Create a dbm-db2 profile named dbm125 that connects to the DBM Data Service at host dbm125 and port 1443 and requires a user and password to be specified on every dbm-db2 command. DBM Data Service access to Db2 subsystems SUBA and SUBB uses prod@host1.com:322 and test@host2.com:522, respectively"
+    },
+    {
+      "options": "dbm126 --job-cards \"//DB2DVOPS JOB (123456789),'DB2 PROVISIONING',NOTIFY=&SYSUID,\" \"//     CLASS=A,MSGCLASS=X,MSGLEVEL=(1,1),\" \"//     REGION=0M,TIME=NOLIMIT\"",
+      "description": "Create a dbm-db2 profile named dbm126 that uses specified job cards for every mainframe job"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/create/endevor-location.jsonc
+++ b/profiles/create/endevor-location.jsonc
@@ -1,0 +1,212 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-location-profile",
+  "aliases": [
+    "endevor-location"
+  ],
+  "summary": "Create a endevor-location profile",
+  "description": "The Endevor element location, where you specify your working environment, system and subsystem",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config init' command",
+  "customize": {
+    "profileTypeIdentifier": "endevor-location"
+  },
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the new endevor-location profile. You can load this profile by using the name on commands that support the \"--endevor-location-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "options": [
+    {
+      "description": "The STC/datasource of the session",
+      "type": "string",
+      "name": "instance",
+      "aliases": [
+        "i"
+      ],
+      "defaultValue": "ENDEVOR",
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor environment where your project resides",
+      "type": "string",
+      "name": "environment",
+      "aliases": [
+        "env"
+      ],
+      "defaultValue": "DEV",
+      "stringLengthRange": [
+        1,
+        8
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor system where the element resides",
+      "type": "string",
+      "name": "system",
+      "aliases": [
+        "sys"
+      ],
+      "stringLengthRange": [
+        1,
+        8
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor subsystem where your element resides",
+      "type": "string",
+      "name": "subsystem",
+      "aliases": [
+        "sub"
+      ],
+      "stringLengthRange": [
+        1,
+        8
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "Name of the Endevor element's type",
+      "type": "string",
+      "name": "type",
+      "aliases": [
+        "typ"
+      ],
+      "stringLengthRange": [
+        1,
+        8
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor stage where your project resides",
+      "type": "string",
+      "name": "stage-number",
+      "aliases": [
+        "sn"
+      ],
+      "allowableValues": {
+        "values": [
+          "1",
+          "2"
+        ]
+      },
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor comment you want to use when performing an action",
+      "type": "string",
+      "name": "comment",
+      "aliases": [
+        "com"
+      ],
+      "stringLengthRange": [
+        1,
+        40
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor CCID you want to use when performing an action",
+      "type": "string",
+      "name": "ccid",
+      "aliases": [
+        "cci"
+      ],
+      "stringLengthRange": [
+        1,
+        12
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The return code of Endevor that defines a failed action",
+      "type": "number",
+      "name": "maxrc",
+      "defaultValue": 8,
+      "group": "Options",
+      "aliases": []
+    },
+    {
+      "description": "Always override element signout, without having to specify the override signout option on each command",
+      "type": "boolean",
+      "name": "override-signout",
+      "aliases": [
+        "os"
+      ],
+      "defaultValue": false,
+      "group": "Options"
+    },
+    {
+      "name": "overwrite",
+      "aliases": [
+        "ow"
+      ],
+      "description": "Overwrite the endevor-location profile when a profile of the same name exists.",
+      "type": "boolean",
+      "group": "Options"
+    },
+    {
+      "name": "disable-defaults",
+      "aliases": [
+        "dd"
+      ],
+      "description": "Disable populating profile values of undefined properties with default values.",
+      "type": "boolean",
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "examples": [
+    {
+      "options": "ndvrLoc --env ENV --sys SYS --sub SUBSYS --typ COBOL --sn 1 -i ENDEVOR",
+      "description": "Create a location profile called 'ndvrLoc' to work at Endevor location ENV/1/SYS/SUBSYS, with elements of type COBOL, using Endevor web services configuration ENDEVOR"
+    },
+    {
+      "options": "ndvrLoc2 --env ENV --sys SYS --sub SUBSYS --sn 1 --com 'sample comment' --cci 'CCID'",
+      "description": "Create a location profile called 'ndvrLoc2' to work at Endevor location ENV/1/SYS/SUBSYS, using CCID 'CCID' and comment 'sample comment'"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/create/endevor.jsonc
+++ b/profiles/create/endevor.jsonc
@@ -1,0 +1,168 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-profile",
+  "aliases": [
+    "endevor"
+  ],
+  "summary": "Create a endevor profile",
+  "description": "The endevor profile schema, where you specify your endevor session information and credentials",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config init' command",
+  "customize": {
+    "profileTypeIdentifier": "endevor"
+  },
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the new endevor profile. You can load this profile by using the name on commands that support the \"--endevor-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "options": [
+    {
+      "description": "The hostname of the endevor session",
+      "type": "string",
+      "name": "host",
+      "aliases": [
+        "hostname"
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The port number of the endevor session",
+      "type": "number",
+      "name": "port",
+      "aliases": [
+        "p"
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The username of the endevor session",
+      "type": "string",
+      "name": "user",
+      "aliases": [
+        "username"
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The password of the user",
+      "type": "string",
+      "name": "password",
+      "aliases": [
+        "pass"
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The protocol used for connecting to Endevor Rest API",
+      "type": "string",
+      "name": "protocol",
+      "aliases": [
+        "prot"
+      ],
+      "defaultValue": "https",
+      "allowableValues": {
+        "values": [
+          "http",
+          "https"
+        ],
+        "caseSensitive": false
+      },
+      "group": "Options"
+    },
+    {
+      "description": "The base path used for connecting to Endevor Rest API",
+      "type": "string",
+      "name": "base-path",
+      "aliases": [
+        "bp"
+      ],
+      "defaultValue": "EndevorService/api/v2",
+      "group": "Options"
+    },
+    {
+      "description": "If set, the server certificate is verified against the list of supplied CAs",
+      "type": "boolean",
+      "name": "reject-unauthorized",
+      "aliases": [
+        "ru"
+      ],
+      "group": "Options"
+    },
+    {
+      "description": "The default path where any reports will be written to, either absolute or relative to current directory",
+      "type": "string",
+      "name": "report-dir",
+      "aliases": [
+        "rd"
+      ],
+      "defaultValue": ".",
+      "group": "Options"
+    },
+    {
+      "name": "overwrite",
+      "aliases": [
+        "ow"
+      ],
+      "description": "Overwrite the endevor profile when a profile of the same name exists.",
+      "type": "boolean",
+      "group": "Options"
+    },
+    {
+      "name": "disable-defaults",
+      "aliases": [
+        "dd"
+      ],
+      "description": "Disable populating profile values of undefined properties with default values.",
+      "type": "boolean",
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "examples": [
+    {
+      "options": "ndvrSample --host ndvr123 --port 8080 --user ibmuser --password myp4ss --prot http --base-path  EndevorService/api/v2 --reject-unauthorized false",
+      "description": "Create an endevor profile called 'ndvrSample' to connect to Endevor web services at host ndvr123 and port 8080,using http protocol, with / EndevorService/api/v2 base path, allowing self-signed certificates"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/delete/dbm-db2.jsonc
+++ b/profiles/delete/dbm-db2.jsonc
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "dbm-db2-profile",
+  "aliases": [
+    "dbm-db2"
+  ],
+  "summary": "Delete a dbm-db2 profile.",
+  "description": "Delete a dbm-db2 profile. You must specify a profile name to be deleted. To find a list of available profiles for deletion, issue the profiles list command. By default, you will be prompted to confirm the profile removal.",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "Edit your Zowe V2 configuration\n    zowe.config.json",
+  "customize": {
+    "profileTypeIdentifier": "dbm-db2"
+  },
+  "options": [
+    {
+      "name": "force",
+      "aliases": [],
+      "description": "Force deletion of profile, and dependent profiles if specified. No prompt will be displayed before  deletion occurs.",
+      "type": "boolean",
+      "required": false,
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the dbm-db2  profile to be deleted. You can also load this profile by using the name on commands that support the \"--dbm-db2-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "examples": [
+    {
+      "options": "profilename",
+      "description": "Delete a dbm-db2 profile named profilename"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/delete/endevor-location.jsonc
+++ b/profiles/delete/endevor-location.jsonc
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-location-profile",
+  "aliases": [
+    "endevor-location"
+  ],
+  "summary": "Delete a endevor-location profile.",
+  "description": "Delete a endevor-location profile. You must specify a profile name to be deleted. To find a list of available profiles for deletion, issue the profiles list command. By default, you will be prompted to confirm the profile removal.",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "Edit your Zowe V2 configuration\n    zowe.config.json",
+  "customize": {
+    "profileTypeIdentifier": "endevor-location"
+  },
+  "options": [
+    {
+      "name": "force",
+      "aliases": [],
+      "description": "Force deletion of profile, and dependent profiles if specified. No prompt will be displayed before  deletion occurs.",
+      "type": "boolean",
+      "required": false,
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the endevor-location  profile to be deleted. You can also load this profile by using the name on commands that support the \"--endevor-location-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "examples": [
+    {
+      "options": "profilename",
+      "description": "Delete a endevor-location profile named profilename"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/delete/endevor.jsonc
+++ b/profiles/delete/endevor.jsonc
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-profile",
+  "aliases": [
+    "endevor"
+  ],
+  "summary": "Delete a endevor profile.",
+  "description": "Delete a endevor profile. You must specify a profile name to be deleted. To find a list of available profiles for deletion, issue the profiles list command. By default, you will be prompted to confirm the profile removal.",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "Edit your Zowe V2 configuration\n    zowe.config.json",
+  "customize": {
+    "profileTypeIdentifier": "endevor"
+  },
+  "options": [
+    {
+      "name": "force",
+      "aliases": [],
+      "description": "Force deletion of profile, and dependent profiles if specified. No prompt will be displayed before  deletion occurs.",
+      "type": "boolean",
+      "required": false,
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the endevor  profile to be deleted. You can also load this profile by using the name on commands that support the \"--endevor-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "examples": [
+    {
+      "options": "profilename",
+      "description": "Delete a endevor profile named profilename"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/list/dbm-db2.jsonc
+++ b/profiles/list/dbm-db2.jsonc
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "dbm-db2-profiles",
+  "aliases": [
+    "dbm-db2"
+  ],
+  "summary": "List profiles of the type dbm-db2.",
+  "description": "The dbm-db2 profile is a named set of DBM Data Service parameters that are implicitly used with the zowe dbm-db2 commands. The profile includes server connection, z/OS execution, and user-dependent details.",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config list' command",
+  "customize": {
+    "profileTypeIdentifier": "dbm-db2"
+  },
+  "options": [
+    {
+      "name": "show-contents",
+      "aliases": [
+        "sc"
+      ],
+      "description": "List dbm-db2  profiles  and their contents. All profile details will be printed as part of command output.",
+      "type": "boolean",
+      "required": false,
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "examples": [
+    {
+      "options": "",
+      "description": "List profiles of type dbm-db2"
+    },
+    {
+      "options": "--sc",
+      "description": "List profiles of type dbm-db2 and display their contents"
+    }
+  ],
+  "positionals": [],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/list/endevor-location.jsonc
+++ b/profiles/list/endevor-location.jsonc
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-location-profiles",
+  "aliases": [
+    "endevor-location"
+  ],
+  "summary": "List profiles of the type endevor-location.",
+  "description": "The Endevor element location, where you specify your working environment, system and subsystem",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config list' command",
+  "customize": {
+    "profileTypeIdentifier": "endevor-location"
+  },
+  "options": [
+    {
+      "name": "show-contents",
+      "aliases": [
+        "sc"
+      ],
+      "description": "List endevor-location  profiles  and their contents. All profile details will be printed as part of command output.",
+      "type": "boolean",
+      "required": false,
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "examples": [
+    {
+      "options": "",
+      "description": "List profiles of type endevor-location"
+    },
+    {
+      "options": "--sc",
+      "description": "List profiles of type endevor-location and display their contents"
+    }
+  ],
+  "positionals": [],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/list/endevor.jsonc
+++ b/profiles/list/endevor.jsonc
@@ -1,0 +1,75 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-profiles",
+  "aliases": [
+    "endevor"
+  ],
+  "summary": "List profiles of the type endevor.",
+  "description": "The endevor profile schema, where you specify your endevor session information and credentials",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config list' command",
+  "customize": {
+    "profileTypeIdentifier": "endevor"
+  },
+  "options": [
+    {
+      "name": "show-contents",
+      "aliases": [
+        "sc"
+      ],
+      "description": "List endevor  profiles  and their contents. All profile details will be printed as part of command output.",
+      "type": "boolean",
+      "required": false,
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "examples": [
+    {
+      "options": "",
+      "description": "List profiles of type endevor"
+    },
+    {
+      "options": "--sc",
+      "description": "List profiles of type endevor and display their contents"
+    }
+  ],
+  "positionals": [],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/set-default/dbm-db2.jsonc
+++ b/profiles/set-default/dbm-db2.jsonc
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "dbm-db2-profile",
+  "aliases": [
+    "dbm-db2"
+  ],
+  "summary": "Set the default\n profiles for the dbm-db2 group",
+  "description": "The dbm-db2 set default-profiles command allows you to set the default profiles for this command group. When a dbm-db2 command is issued and no profile override options are specified, the default profiles for the command group are automatically loaded for the command based on the commands profile requirements.",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config set' command",
+  "options": [
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specify a\n profile for default usage within the dbm-db2 group. When you issue commands within the dbm-db2 group without a profile specified as part of the command, the default will be loaded instead.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "customize": {
+    "profileTypeIdentifier": "dbm-db2"
+  },
+  "examples": [
+    {
+      "options": "profilename",
+      "description": "Set the default profile for type dbm-db2 to the profile named 'profilename'"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/set-default/endevor-location.jsonc
+++ b/profiles/set-default/endevor-location.jsonc
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-location-profile",
+  "aliases": [
+    "endevor-location"
+  ],
+  "summary": "Set the default\n profiles for the endevor-location group",
+  "description": "The endevor-location set default-profiles command allows you to set the default profiles for this command group. When a endevor-location command is issued and no profile override options are specified, the default profiles for the command group are automatically loaded for the command based on the commands profile requirements.",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config set' command",
+  "options": [
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specify a\n profile for default usage within the endevor-location group. When you issue commands within the endevor-location group without a profile specified as part of the command, the default will be loaded instead.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "customize": {
+    "profileTypeIdentifier": "endevor-location"
+  },
+  "examples": [
+    {
+      "options": "profilename",
+      "description": "Set the default profile for type endevor-location to the profile named 'profilename'"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/set-default/endevor.jsonc
+++ b/profiles/set-default/endevor.jsonc
@@ -1,0 +1,68 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-profile",
+  "aliases": [
+    "endevor"
+  ],
+  "summary": "Set the default\n profiles for the endevor group",
+  "description": "The endevor set default-profiles command allows you to set the default profiles for this command group. When a endevor command is issued and no profile override options are specified, the default profiles for the command group are automatically loaded for the command based on the commands profile requirements.",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config set' command",
+  "options": [
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specify a\n profile for default usage within the endevor group. When you issue commands within the endevor group without a profile specified as part of the command, the default will be loaded instead.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "customize": {
+    "profileTypeIdentifier": "endevor"
+  },
+  "examples": [
+    {
+      "options": "profilename",
+      "description": "Set the default profile for type endevor to the profile named 'profilename'"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/update/dbm-db2.jsonc
+++ b/profiles/update/dbm-db2.jsonc
@@ -1,0 +1,245 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "dbm-db2-profile",
+  "aliases": [
+    "dbm-db2"
+  ],
+  "summary": "Update a dbm-db2 profile. You can update any property present within the profile configuration. The updated profile will be printed so that you can review the result of the updates.",
+  "description": "The dbm-db2 profile is a named set of DBM Data Service parameters that are implicitly used with the zowe dbm-db2 commands. The profile includes server connection, z/OS execution, and user-dependent details.",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config set' command",
+  "customize": {
+    "profileTypeIdentifier": "dbm-db2"
+  },
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the new dbm-db2 profile. You can load this profile by using the name on commands that support the \"--dbm-db2-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "options": [
+    {
+      "name": "job-cards",
+      "aliases": [
+        "jc"
+      ],
+      "description": "Specifies a string array of z/OS JCL JOB statements.",
+      "required": false,
+      "type": "array",
+      "group": "dbm-db2 Common Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "work-dataset-prefix",
+      "aliases": [
+        "wdp"
+      ],
+      "description": "Specifies the prefix that is used as the high level qualifier in z/OS work data set names.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Common Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "authid",
+      "aliases": [
+        "a"
+      ],
+      "description": "Specifies the primary Db2 authorization ID (user ID) that is used to establish a connection between Db2 and a process.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Common Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "sqlid",
+      "aliases": [
+        "s"
+      ],
+      "description": "Specifies the authorization ID that is used as the value in generated SET CURRENT SQLID statements most of the time.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Common Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "termination-character",
+      "aliases": [
+        "tc"
+      ],
+      "description": "Specifies the SQL termination character that you want to use to terminate object DDL for triggers, XML indexes, functions, and procedures that contain embedded semicolon-terminated SQL statements. You cannot use a comma, an underscore, a single quote, double quotes, left parentheses, or right parentheses for this value.",
+      "required": false,
+      "type": "string",
+      "stringLengthRange": [
+        1,
+        1
+      ],
+      "group": "dbm-db2 Common Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "overwrite-output-files",
+      "aliases": [
+        "oof"
+      ],
+      "description": "Specifies whether to overwrite output files when they already exist.",
+      "required": false,
+      "type": "boolean",
+      "group": "dbm-db2 Common Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "host",
+      "aliases": [
+        "H"
+      ],
+      "description": "Specifies the DBM Data Service REST API server host name or TCP/IP address to use.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Connection Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "port",
+      "aliases": [
+        "P"
+      ],
+      "description": "Specifies the DBM Data Service REST API server TCP/IP port number.",
+      "required": false,
+      "type": "number",
+      "group": "dbm-db2 Connection Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "user",
+      "aliases": [
+        "u"
+      ],
+      "description": "Specifies the mainframe user name that you want to use to connect to the mainframe systems during execution of the Zowe CLI commands. This user name can be the same as your TSO login ID.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Connection Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "password",
+      "aliases": [
+        "pass",
+        "pw"
+      ],
+      "description": "Specifies the mainframe password for the user name that is used to connect to the mainframe systems during execution of the CLI commands. This password can be the same as your TSO password.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Connection Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "reject-unauthorized",
+      "aliases": [
+        "ru"
+      ],
+      "description": "Determines whether the dbm-db2 command is accepted or rejected when a self-signed certificate is returned by the DBM Data Service.",
+      "required": false,
+      "type": "boolean",
+      "group": "dbm-db2 Connection Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "protocol",
+      "description": "Specifies the communication protocol to use between the zowe dbm-db2 client and the DBM Data Service.",
+      "required": false,
+      "type": "string",
+      "allowableValues": {
+        "values": [
+          "http",
+          "https"
+        ]
+      },
+      "group": "dbm-db2 Connection Options",
+      "absenceImplications": null,
+      "implies": null,
+      "aliases": []
+    },
+    {
+      "name": "environment-list",
+      "aliases": [
+        "el"
+      ],
+      "description": "Specifies an object of one or more values consisting of a Db2 subsystem ID and a DBM Data Service environment pair. The paired entry identifies the DBM Data Service environment to use for a subsystem that is accessible through multiple DBM Data Service environments. For more information about configuring the DBM Data Service, see the Database Management Solutions for Db2 for z/OS documentation at https://techdocs.broadcom.com/db2mgmt.",
+      "required": false,
+      "type": "string",
+      "group": "dbm-db2 Connection Options",
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "examples": [
+    {
+      "options": "profile_name1 --work-dataset-prefix NEWPREFX.DDL",
+      "description": "Update a dbm-db2 profile named profile_name1 with a new work data set prefix"
+    },
+    {
+      "options": "dbm123 --user newuser --password newp4ss",
+      "description": "Update a dbm-db2 profile named dbm123 with a new username and password"
+    },
+    {
+      "options": "dbm124 --environment-list \"SUBA:prod@host4.com:322,SUBC:stage@host3.net:722\"",
+      "description": "Update a dbm-db2 profile named dbm124 with a new environment list. Existing subsystem SUBA will be updated with a new hostname \"host4\" and subsystem SUBC will be added to the list"
+    },
+    {
+      "options": "dbm125 --job-cards \"//NEWJOBNM JOB (123456789),\" \"//     CLASS=A,MSGCLASS=X,MSGLEVEL=(1,1),\"",
+      "description": "Update a dbm-db2 profile named dbm125 with new job cards"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/update/endevor-location.jsonc
+++ b/profiles/update/endevor-location.jsonc
@@ -1,0 +1,210 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-location-profile",
+  "aliases": [
+    "endevor-location"
+  ],
+  "summary": "Update a endevor-location profile. You can update any property present within the profile configuration. The updated profile will be printed so that you can review the result of the updates.",
+  "description": "The Endevor element location, where you specify your working environment, system and subsystem",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config set' command",
+  "customize": {
+    "profileTypeIdentifier": "endevor-location"
+  },
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the new endevor-location profile. You can load this profile by using the name on commands that support the \"--endevor-location-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "options": [
+    {
+      "description": "The STC/datasource of the session",
+      "type": "string",
+      "name": "instance",
+      "aliases": [
+        "i"
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor environment where your project resides",
+      "type": "string",
+      "name": "environment",
+      "aliases": [
+        "env"
+      ],
+      "stringLengthRange": [
+        1,
+        8
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor system where the element resides",
+      "type": "string",
+      "name": "system",
+      "aliases": [
+        "sys"
+      ],
+      "stringLengthRange": [
+        1,
+        8
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor subsystem where your element resides",
+      "type": "string",
+      "name": "subsystem",
+      "aliases": [
+        "sub"
+      ],
+      "stringLengthRange": [
+        1,
+        8
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "Name of the Endevor element's type",
+      "type": "string",
+      "name": "type",
+      "aliases": [
+        "typ"
+      ],
+      "stringLengthRange": [
+        1,
+        8
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor stage where your project resides",
+      "type": "string",
+      "name": "stage-number",
+      "aliases": [
+        "sn"
+      ],
+      "allowableValues": {
+        "values": [
+          "1",
+          "2"
+        ]
+      },
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor comment you want to use when performing an action",
+      "type": "string",
+      "name": "comment",
+      "aliases": [
+        "com"
+      ],
+      "stringLengthRange": [
+        1,
+        40
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The Endevor CCID you want to use when performing an action",
+      "type": "string",
+      "name": "ccid",
+      "aliases": [
+        "cci"
+      ],
+      "stringLengthRange": [
+        1,
+        12
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The return code of Endevor that defines a failed action",
+      "type": "number",
+      "name": "maxrc",
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options",
+      "aliases": []
+    },
+    {
+      "description": "Always override element signout, without having to specify the override signout option on each command",
+      "type": "boolean",
+      "name": "override-signout",
+      "aliases": [
+        "os"
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/update/endevor.jsonc
+++ b/profiles/update/endevor.jsonc
@@ -1,0 +1,165 @@
+// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "endevor-profile",
+  "aliases": [
+    "endevor"
+  ],
+  "summary": "Update a endevor profile. You can update any property present within the profile configuration. The updated profile will be printed so that you can review the result of the updates.",
+  "description": "The endevor profile schema, where you specify your endevor session information and credentials",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config set' command",
+  "customize": {
+    "profileTypeIdentifier": "endevor"
+  },
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the new endevor profile. You can load this profile by using the name on commands that support the \"--endevor-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "options": [
+    {
+      "description": "The hostname of the endevor session",
+      "type": "string",
+      "name": "host",
+      "aliases": [
+        "hostname"
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The port number of the endevor session",
+      "type": "number",
+      "name": "port",
+      "aliases": [
+        "p"
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The username of the endevor session",
+      "type": "string",
+      "name": "user",
+      "aliases": [
+        "username"
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The password of the user",
+      "type": "string",
+      "name": "password",
+      "aliases": [
+        "pass"
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The protocol used for connecting to Endevor Rest API",
+      "type": "string",
+      "name": "protocol",
+      "aliases": [
+        "prot"
+      ],
+      "allowableValues": {
+        "values": [
+          "http",
+          "https"
+        ],
+        "caseSensitive": false
+      },
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The base path used for connecting to Endevor Rest API",
+      "type": "string",
+      "name": "base-path",
+      "aliases": [
+        "bp"
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "If set, the server certificate is verified against the list of supplied CAs",
+      "type": "boolean",
+      "name": "reject-unauthorized",
+      "aliases": [
+        "ru"
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "description": "The default path where any reports will be written to, either absolute or relative to current directory",
+      "type": "string",
+      "name": "report-dir",
+      "aliases": [
+        "rd"
+      ],
+      "required": false,
+      "absenceImplications": null,
+      "implies": null,
+      "group": "Options"
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-examples",
+      "group": "Global options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}


### PR DESCRIPTION
Contributes the DBM-DB2 and Endevor plug-ins, which has achieved Zowe V2 Conformance.
Updates the gitignore file to ignore .bak files, making life easier for people who need to switch between different copyrights or components to contribute.

Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>