### PR TITLE
Update web help, scripts, and dependencies

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,13 +26,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/resources/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: lts/*
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: lts/*
 
@@ -84,30 +84,16 @@ jobs:
     - name: Archive Results
       id: upload
       if: ${{ always() && steps.build.outcome == 'success' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: results
         path: |
           generatedWebHelp/
           zowe.pdf
     
-    - name: Create Release
-      id: release-create
-      if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/zowe-v1-lts') && steps.build.outcome == 'success' && github.event_name == 'workflow_dispatch' && github.event.inputs.zowe-version && github.event.inputs.zowe-version != '' && github.event.inputs.release == 'true' }}
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        draft: false
-        prerelease: false
-        release_name: ${{ github.event.inputs.zowe-version }}
-        tag_name: ${{ github.event.inputs.zowe-version }}
-        body: |
-          Zowe CLI Web-Help for Zowe Release ${{ github.event.inputs.zowe-version }}
-    
     - name: Prepare Release Artifacts
       id: release-prepare
-      if: ${{ steps.release-create.outcome == 'success' }}
+      if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/zowe-v1-lts') && steps.build.outcome == 'success' && github.event_name == 'workflow_dispatch' && github.event.inputs.zowe-version && github.event.inputs.zowe-version != '' && github.event.inputs.release == 'true' }}
       run: |
         mkdir release
         mv zowe.pdf release/.
@@ -119,26 +105,17 @@ jobs:
         zip -roX "zowe-${{ github.event.inputs.zowe-version }}-WebHelp.zip" "zowe-${{ github.event.inputs.zowe-version }}-WebHelp"
         TZ=UTC touch -t 197001010000.00 zowe-${{ github.event.inputs.zowe-version }}-WebHelp.zip
 
-    - name: Upload Release Artifacts - PDF
-      id: release-upload-pdf
+    - name: Create Release
+      id: release-create
       if: ${{ steps.release-prepare.outcome == 'success' }}
-      uses: actions/upload-release-asset@v1
+      uses: ncipollo/release-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.release-create.outputs.upload_url }}
-        asset_path: ./release/zowe-${{ github.event.inputs.zowe-version }}.pdf
-        asset_name: zowe-${{ github.event.inputs.zowe-version }}.pdf
-        asset_content_type: application/pdf
-    
-    - name: Upload Release Artifacts - ZIP
-      id: release-upload-zip
-      if: ${{ steps.release-prepare.outcome == 'success' }}
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.release-create.outputs.upload_url }}
-        asset_path: ./release/zowe-${{ github.event.inputs.zowe-version }}-WebHelp.zip
-        asset_name: zowe-${{ github.event.inputs.zowe-version }}-WebHelp.zip
-        asset_content_type: application/zip
+        draft: false
+        prerelease: false
+        name: ${{ github.event.inputs.zowe-version }}
+        tag: ${{ github.event.inputs.zowe-version }}
+        body: |
+          Zowe CLI Web-Help for Zowe Release ${{ github.event.inputs.zowe-version }}
+        artifacts: "release/zowe-${{ github.event.inputs.zowe-version }}.pdf,release/zowe-${{ github.event.inputs.zowe-version }}-WebHelp.zip"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Get Zowe version
       id: get-version
       if: ${{ steps.get-version-from-workflow.outcome == 'skipped' }}
-      run: echo "::set-output name=number::$(echo 'CLI_v'$(npx zowe --version))"
+      run: echo "number=$(echo 'CLI_v'$(npx zowe --version))" >> $GITHUB_OUTPUT
 
     - name: Build Web Help
       id: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,6 @@ jobs:
 
     - name: Get Zowe version
       id: get-version
-      if: ${{ steps.get-version-from-workflow.outcome == 'skipped' }}
       run: |
         echo "number=$(echo 'CLI_v'$(npx zowe --version))" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       id: get-version
       if: ${{ steps.get-version-from-workflow.outcome == 'skipped' }}
       run: |
-        echo "::set-output name=number::$(echo 'CLI_v'$(zowe --version))"
+        echo "number=$(echo 'CLI_v'$(npx zowe --version))" >> $GITHUB_OUTPUT
 
     - name: Setup zowe.json file
       id: setup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: lts/*
 
@@ -75,7 +75,7 @@ jobs:
     - name: Archive Results
       id: upload
       if: ${{ always() && steps.build.outcome == 'success' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: results
         path: |

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -15,7 +15,7 @@ jobs:
       id: files
       uses: tj-actions/changed-files@v35
       with:
-        files: **.*.json
+        files: "**/*.json"
     - run: |
         readarray -t all_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.all_changed_files }}')"
         for file in ${all_files[@]}; do

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,15 +9,15 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get Changed Files
       id: files
-      uses: jitterbit/get-changed-files@v1
+      uses: tj-actions/changed-files@v35
       with:
-        format: 'json'
+        files: **.*.json
     - run: |
-        readarray -t all_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.all }}')"
+        readarray -t all_files <<<"$(jq -r '.[]' <<<'${{ steps.files.outputs.all_changed_files }}')"
         for file in ${all_files[@]}; do
           [[ ''${file}'' == *.jsonc ]] || (echo "Not a JSON file: ${file}" && exit 1)
           [[ ''${file}'' == commandGroups/* ]] || [[ ''${file}'' == profiles/* ]] || (echo "Wrong location: ${file}" && exit 1)

--- a/commandGroups/dbm-db2.jsonc
+++ b/commandGroups/dbm-db2.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "dbm-db2",
@@ -73,7 +73,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -83,7 +83,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -92,23 +92,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -235,11 +228,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -248,23 +248,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -280,7 +273,7 @@
       "children": [
         {
           "name": "ddl",
-          "description": "Compare objects that are defined in a DDL file to objects that are defined on a Db2 subsystem and generate an update script to implement the necessary object changes. This command also generates a summary report that provides a high-level overview of the changes. You can execute the script that is generated from this command using the 'zowe dbm-db2 execute compare-script' command.",
+          "description": "Compare objects that are defined in a DDL file to objects that are defined on a Db2 subsystem and generate an update script to implement the necessary object changes. This command also generates a high-level change summary report and a parseable impact analysis report. You can execute the script that is generated from this command using the 'zowe dbm-db2 execute compare-script' command.",
           "type": "command",
           "handler": "",
           "profile": {
@@ -386,10 +379,20 @@
             },
             {
               "name": "output-summary-file",
-              "description": "Specifies the local output file name that provides a summary of the changes to be performed to the Db2 objects on the target Db2 subsystem. The file summarizes what the changes are, but not how the changes are made.\n      \n\u001b[90m Default value: summary.txt \u001b[0m",
+              "description": "Specifies the local output file name that contains the change summary report in textual format. This report provides an overview of the changes to be performed to the Db2 objects on the target Db2 subsystem, but it does not describe how the changes are made.\n      \n\u001b[90m Default value: summary.txt \u001b[0m",
               "type": "string",
               "aliases": [
                 "osf"
+              ],
+              "required": false,
+              "group": "Options"
+            },
+            {
+              "name": "output-impact-file",
+              "description": "Specifies the local output file name that contains the parseable impact analysis report in JSON or YAML format. This report helps identify significant DDL operations to be performed on Db2 objects. It provides the total number and type of DDL operations that are being performed on each object type, the list of DDL operations performed on each object instance, and the state of any pending changes.\n \nThe report format is determined by the supplied file name extension: .json for JSON and .yaml or .yml for YAML. If no extension is provided, JSON format is used.\n      \n\u001b[90m Default value: impact.json\n\nFor more information about the impact analysis report, see the RC/Migrator documentation at https://techdocs.broadcom.com/db2rcmig. \u001b[0m",
+              "type": "string",
+              "aliases": [
+                "oif"
               ],
               "required": false,
               "group": "Options"
@@ -416,7 +419,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -426,7 +429,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -435,23 +438,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -568,11 +564,11 @@
             },
             {
               "options": "myddl.sql --target-db2 TEST --rule-set USER1.RULESET",
-              "description": "Generate a script to update objects and apply a rule-set for the matched objects"
+              "description": "Generate a script to update objects and apply a rule set for the matched objects"
             },
             {
               "options": "myddl.sql --target-db2 TEST --rule-set USER1.RULESET --match-set-file pair.txt",
-              "description": "Generate a script to update objects and apply a ruleset for the objects matched as determined by the local mask specifications in the pair.txt file"
+              "description": "Generate a script to update objects and apply a rule set for the objects matched as determined by the local mask specifications in the pair.txt file"
             }
           ],
           "aliases": [],
@@ -582,11 +578,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -595,23 +598,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -725,7 +721,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -735,7 +731,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -744,23 +740,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -891,11 +880,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -904,23 +900,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -950,10 +939,12 @@
           },
           "options": [
             {
-              "name": "output-recovery-file",
-              "description": "Specifies the local output recovery file that contains the recovery script that is generated during execution of this command. Executing the recovery script using the 'zowe dbm-db2 execute script' command undoes the changes that were made by execution of the compare-script. \n      \n\u001b[90m Default value: recovery.txt \u001b[0m",
+              "name": "output-recovery-script",
+              "description": "Specifies the local output file name that contains the recovery script that is generated during execution of this command. Executing the recovery script using the 'zowe dbm-db2 execute script' command undoes the changes that were made by execution of the compare-script. \n      \n\u001b[90m Default value: recovery.txt \u001b[0m",
               "type": "string",
               "aliases": [
+                "ors",
+                "output-recovery-file",
                 "orf"
               ],
               "required": false,
@@ -991,7 +982,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -1001,7 +992,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -1010,23 +1001,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -1224,7 +1208,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -1234,7 +1218,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -1243,23 +1227,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -1454,7 +1431,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -1464,7 +1441,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -1473,23 +1450,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -1620,11 +1590,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -1633,23 +1610,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -1778,7 +1748,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -1788,7 +1758,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -1797,23 +1767,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -1941,11 +1904,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -1954,23 +1924,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -2102,7 +2065,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -2112,7 +2075,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -2121,23 +2084,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -2261,11 +2217,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -2274,23 +2237,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -2306,11 +2262,18 @@
   ],
   "options": [
     {
+      "name": "help-examples",
+      "group": "Global Options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
       "name": "response-format-json",
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -2319,23 +2282,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/commandGroups/endevor-bridge-for-git.jsonc
+++ b/commandGroups/endevor-bridge-for-git.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "endevor-bridge-for-git",
@@ -149,6 +149,22 @@
               "description": "If specified, only elements from the Endevor work environment will be synchronized.",
               "type": "boolean",
               "required": false,
+              "group": "Options",
+              "aliases": []
+            },
+            {
+              "name": "mapping-mode",
+              "description": "Mapping mode of the mapping ('FULL', 'WORK_ENV_ONLY' or 'MIRROR')",
+              "type": "string",
+              "required": false,
+              "allowableValues": {
+                "values": [
+                  "FULL",
+                  "WORK_ENV_ONLY",
+                  "MIRROR"
+                ],
+                "caseSensitive": true
+              },
               "group": "Options",
               "aliases": []
             },
@@ -307,7 +323,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -317,7 +333,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -326,23 +342,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -540,7 +549,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -550,7 +559,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -559,23 +568,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -747,7 +749,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -757,7 +759,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -766,23 +768,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -934,11 +929,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -947,23 +949,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -1185,7 +1180,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -1195,7 +1190,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -1204,23 +1199,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -1656,7 +1644,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -1666,7 +1654,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -1675,23 +1663,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -2048,7 +2029,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -2058,7 +2039,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -2067,23 +2048,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -2404,11 +2378,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -2417,23 +2398,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -2534,7 +2508,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -2544,7 +2518,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -2553,23 +2527,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -2868,7 +2835,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -2878,7 +2845,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -2887,23 +2854,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -3093,7 +3053,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -3103,7 +3063,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -3112,23 +3072,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -3299,7 +3252,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -3309,7 +3262,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -3318,23 +3271,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -3526,7 +3472,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -3536,7 +3482,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -3545,23 +3491,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -3726,11 +3665,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -3739,23 +3685,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -3891,7 +3830,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -3901,7 +3840,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -3910,23 +3849,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -4091,11 +4023,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -4104,23 +4043,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -4229,7 +4161,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -4239,7 +4171,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -4248,23 +4180,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -4430,7 +4355,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -4440,7 +4365,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -4449,23 +4374,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -4625,7 +4543,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -4635,7 +4553,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -4644,23 +4562,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -4807,11 +4718,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -4820,23 +4738,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -5017,6 +4928,22 @@
               "aliases": []
             },
             {
+              "name": "mapping-mode",
+              "description": "Mapping mode of the mapping ('FULL', 'WORK_ENV_ONLY' or 'MIRROR')",
+              "type": "string",
+              "required": false,
+              "allowableValues": {
+                "values": [
+                  "FULL",
+                  "WORK_ENV_ONLY",
+                  "MIRROR"
+                ],
+                "caseSensitive": true
+              },
+              "group": "Options",
+              "aliases": []
+            },
+            {
               "name": "json-file",
               "aliases": [
                 "json"
@@ -5183,7 +5110,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -5193,7 +5120,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -5202,23 +5129,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -5418,7 +5338,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -5428,7 +5348,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -5437,23 +5357,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -5632,7 +5545,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -5642,7 +5555,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -5651,23 +5564,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -6072,7 +5978,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -6082,7 +5988,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -6091,23 +5997,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -6272,11 +6171,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -6285,23 +6191,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -6373,7 +6272,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -6383,7 +6282,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -6392,23 +6291,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -6542,7 +6434,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -6552,7 +6444,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -6561,23 +6453,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -6692,7 +6577,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -6702,7 +6587,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -6711,23 +6596,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -6777,11 +6655,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -6790,23 +6675,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -6850,7 +6728,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -6860,7 +6738,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -6869,23 +6747,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -7064,7 +6935,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -7074,7 +6945,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -7083,23 +6954,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -7337,7 +7201,7 @@
             },
             {
               "name": "show-inputs-only",
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Show command inputs and do not run the command",
               "type": "boolean",
               "aliases": []
@@ -7347,7 +7211,7 @@
               "aliases": [
                 "rfj"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Produce JSON formatted data from a command",
               "type": "boolean"
             },
@@ -7356,23 +7220,16 @@
               "aliases": [
                 "h"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display help text",
               "type": "boolean"
-            },
-            {
-              "name": "help-examples",
-              "group": "Global options",
-              "description": "Display examples for all the commands in a group",
-              "type": "boolean",
-              "aliases": []
             },
             {
               "name": "help-web",
               "aliases": [
                 "hw"
               ],
-              "group": "Global options",
+              "group": "Global Options",
               "description": "Display HTML help in browser",
               "type": "boolean"
             },
@@ -7578,11 +7435,18 @@
       ],
       "options": [
         {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
           "name": "response-format-json",
           "aliases": [
             "rfj"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Produce JSON formatted data from a command",
           "type": "boolean"
         },
@@ -7591,23 +7455,16 @@
           "aliases": [
             "h"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display help text",
           "type": "boolean"
-        },
-        {
-          "name": "help-examples",
-          "group": "Global options",
-          "description": "Display examples for all the commands in a group",
-          "type": "boolean",
-          "aliases": []
         },
         {
           "name": "help-web",
           "aliases": [
             "hw"
           ],
-          "group": "Global options",
+          "group": "Global Options",
           "description": "Display HTML help in browser",
           "type": "boolean"
         }
@@ -7621,11 +7478,18 @@
   ],
   "options": [
     {
+      "name": "help-examples",
+      "group": "Global Options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
       "name": "response-format-json",
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -7634,23 +7498,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/commandGroups/idms.jsonc
+++ b/commandGroups/idms.jsonc
@@ -1,0 +1,3591 @@
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "idms",
+  "description": "IDMS plug-in for listing real-time monitor statistics and information, viewing DC log messages, and issuing DCMT and DCUF commands",
+  "type": "group",
+  "children": [
+    {
+      "name": "issue",
+      "aliases": [
+        "iss"
+      ],
+      "summary": "Issue IDMS DCMT and DCUF commands",
+      "description": "Issues IDMS DCMT and DCUF commands",
+      "type": "group",
+      "children": [
+        {
+          "name": "dcmt-display",
+          "aliases": [
+            "dd"
+          ],
+          "summary": "DCMT DISPLAY commands",
+          "description": "Execute a DCMT DISPLAY command",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "args",
+              "type": "string",
+              "description": "DCMT DISPLAY command arguments",
+              "required": true,
+              "group": "Required Options",
+              "aliases": []
+            },
+            {
+              "name": "broadcast",
+              "aliases": [
+                "b"
+              ],
+              "type": "string",
+              "description": "Broadcast parameters used if the system is part of a data sharing group",
+              "group": "Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--args \"task send\"",
+              "description": "Issues a 'dcmt display task send' command to display information associated with the SEND task"
+            },
+            {
+              "options": "--args \"active programs\" --idms-profile myprofile2 --datasource sysdemo",
+              "description": "Issues a 'dcmt display active programs' command with an IDMS profile and data source to override the default"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "dcmt-vary",
+          "aliases": [
+            "dv"
+          ],
+          "summary": "DCMT VARY commands",
+          "description": "Execute a DCMT VARY command",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "args",
+              "type": "string",
+              "description": "DCMT VARY command arguments",
+              "required": true,
+              "group": "Required Options",
+              "aliases": []
+            },
+            {
+              "name": "broadcast",
+              "aliases": [
+                "b"
+              ],
+              "type": "string",
+              "description": "Broadcast parameters used if the system is part of a data sharing group",
+              "group": "Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--args \"task signon enabled\"",
+              "description": "Issues a 'dcmt vary task signon enabled' command to enable the SIGNON task"
+            },
+            {
+              "options": "--args \"journal swap\" --idms-profile myprofile2 --datasource sysdemo",
+              "description": "Issues a 'dcmt vary journal swap' command with an IDMS profile and data source to override the default"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "dcmt-help",
+          "aliases": [
+            "dh"
+          ],
+          "summary": "DCMT HELP command",
+          "description": "Execute a DCMT HELP command",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "args",
+              "type": "string",
+              "description": "DCMT HELP command arguments",
+              "group": "Options",
+              "aliases": []
+            },
+            {
+              "name": "broadcast",
+              "aliases": [
+                "b"
+              ],
+              "type": "string",
+              "description": "Broadcast parameters used if the system is part of a data sharing group",
+              "group": "Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "",
+              "description": "Issues a 'dcmt help' command to display a summary of the syntax for DCMT commands"
+            },
+            {
+              "options": "--args \"task\" --datasource sysdemo",
+              "description": "Issues a 'dcmt help task' command with a data source to override the default"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "dcmt-quiesce",
+          "aliases": [
+            "dq"
+          ],
+          "summary": "DCMT QUIESCE command",
+          "description": "Execute a DCMT QUIESCE command",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "args",
+              "type": "string",
+              "description": "DCMT QUIESCE command arguments. Specifies the DCMT QUIESCE target area, segment, or DBNAME",
+              "required": true,
+              "group": "Required Options",
+              "aliases": []
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--args \"dbname empdemo id 1\"",
+              "description": "Issues the command 'dcmt quiesce dbname empdemo id 1' which quiesces all areas associated with segments included in the EMPDEMO database and assigns the operation to dcmt-id 1"
+            },
+            {
+              "options": "--args \"area emp* id 2\"",
+              "description": "Issues the command 'dcmt quiesce area emp* id 2' which quiesces all areas whose segment name begins with EMP and assigns the operation to dcmt-id 2"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "dcmt-shutdown",
+          "aliases": [
+            "shutdown"
+          ],
+          "summary": "DCMT SHUTDOWN commands",
+          "description": "Execute a DCMT SHUTDOWN command",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "args",
+              "type": "string",
+              "description": "DCMT SHUTDOWN command arguments. NOPROMPT must be specified. IMMEDIATE is optional",
+              "required": true,
+              "group": "Required Options",
+              "aliases": []
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--args \"noprompt\"",
+              "description": "Issues a 'dcmt shutdown noprompt' command to shut down the DC/UCF system while allowing all active tasks and external run units to terminate normally first"
+            },
+            {
+              "options": "--args \"noprompt immediate\"",
+              "description": "Issues a 'dcmt shutdown noprompt immediate' command to immediately shut down the DC/UCF system, abending all active tasks and external run units with code SHUT"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "dcmt-statistics",
+          "aliases": [
+            "ds"
+          ],
+          "summary": "DCMT STATISTICS commands",
+          "description": "Execute a DCMT STATISTICS command",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "args",
+              "type": "string",
+              "description": "DCMT STATISTICS command arguments. Can specify ROLL to reset statistics to zero after writing them",
+              "group": "Options",
+              "aliases": []
+            },
+            {
+              "name": "broadcast",
+              "aliases": [
+                "b"
+              ],
+              "type": "string",
+              "description": "Broadcast parameters used if the system is part of a data sharing group",
+              "group": "Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--args \"roll\"",
+              "description": "Issues a 'dcmt write statistics roll' command to write the current system and line statistics and histograms to the log file and then reset their values to zero"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "dcmt-test",
+          "aliases": [
+            "dt"
+          ],
+          "summary": "DCMT TEST commands",
+          "description": "Execute a DCMT TEST command. Obtains diagnostic information for Broadcom technical support personnel.\n\n The DCMT TEST command is used for debugging and diagnostic purposes only. Use it only when told to do so by IDMS technical support personnel. It is enabled only if certain CSA test flags are turned on",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "args",
+              "type": "string",
+              "description": "DCMT TEST command arguments. Specifies which debugging options to use",
+              "required": true,
+              "group": "Required Options",
+              "aliases": []
+            },
+            {
+              "name": "broadcast",
+              "aliases": [
+                "b"
+              ],
+              "type": "string",
+              "description": "Broadcast parameters used if the system is part of a data sharing group",
+              "group": "Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--args \"debug options\"",
+              "description": "Issues a 'dcmt test debug options' command, with 'debug options' being the options provided by IDMS technical support"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "dcuf-help",
+          "aliases": [
+            "dfh"
+          ],
+          "summary": "DCUF HELP command",
+          "description": "Execute a DCUF HELP command",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "",
+              "description": "Issues a 'dcuf help' command to display a list of DCUF commands and parameters. Note: Only SHOW commands are supported by the CLI"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "dcuf-show",
+          "aliases": [
+            "dfs"
+          ],
+          "summary": "DCUF SHOW commands",
+          "description": "Execute a DCUF SHOW command",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "args",
+              "type": "string",
+              "description": "DCUF SHOW command arguments",
+              "required": true,
+              "group": "Required Options",
+              "aliases": []
+            },
+            {
+              "name": "broadcast",
+              "aliases": [
+                "b"
+              ],
+              "type": "string",
+              "description": "Broadcast parameters used if the system is part of a data sharing group",
+              "group": "Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--args \"tables\"",
+              "description": "Issues a 'dcuf show tables' command to display a list of the available tables"
+            },
+            {
+              "options": "--args \"user username\"",
+              "description": "Issues a 'dcuf show user <username>' command to display information about a specific user"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "required": true,
+              "group": "IDMS Connection Options"
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global Options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global Options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global Options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    },
+    {
+      "name": "list",
+      "aliases": [
+        "ls"
+      ],
+      "summary": "List available datasources, active IDMS systems, log messages, user tasks, and transaction details",
+      "description": "Lists available datasources, real-time monitor statistics information, log messages, active user tasks, and transaction details",
+      "type": "group",
+      "children": [
+        {
+          "name": "datasources",
+          "aliases": [
+            "ds"
+          ],
+          "summary": "Lists defined data sources",
+          "description": "Lists data sources defined to the IDMS REST API",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasourcename",
+              "aliases": [
+                "dsn"
+              ],
+              "description": "Specifies a specific datasource to view the definition of",
+              "type": "string",
+              "group": "Options"
+            },
+            {
+              "name": "all",
+              "aliases": [
+                "a"
+              ],
+              "description": "Lists each datasource defined to the IDMS REST API",
+              "type": "boolean",
+              "defaultValue": null,
+              "group": "Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--all",
+              "description": "Lists all data sources defined to the IDMS Rest API"
+            },
+            {
+              "options": "--dsn SYSDEMO",
+              "description": "Lists a single IDMS data source identified by the data source name"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "systems",
+          "aliases": [
+            "sys"
+          ],
+          "summary": "Lists active IDMS systems",
+          "description": "Lists either all active IDMS systems on an LPAR or lists information about a specific system if a jobname is provided",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "jobname",
+              "aliases": [
+                "j"
+              ],
+              "description": "The job name of the active IDMS system",
+              "type": "string",
+              "group": "Options"
+            },
+            {
+              "name": "all",
+              "aliases": [
+                "a"
+              ],
+              "description": "Lists all active systems. This is the default behavior if no job name is provided",
+              "type": "boolean",
+              "defaultValue": null,
+              "group": "Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--all",
+              "description": "Lists all active IDMS systems on the LPAR where the IDMS REST API service is running"
+            },
+            {
+              "options": "--jobname SYSDEMO",
+              "description": "Lists a single active IDMS system identified by the IDMS system job name"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "log",
+          "summary": "Lists log messages",
+          "description": "Lists log messages based on the search options provided",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options",
+              "required": true
+            },
+            {
+              "name": "start-time",
+              "aliases": [
+                "st"
+              ],
+              "description": "Start time of the first log message\n\nFormat: 'YYYY-MM-DD HH:mm:ss[.SSSSSS]'",
+              "type": "string",
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "end-time",
+              "aliases": [
+                "et"
+              ],
+              "description": "End time of the last log message\n\nFormat: 'YYYY-MM-DD HH:mm:ss[.SSSSSS]'",
+              "type": "string",
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "record-type",
+              "aliases": [
+                "rt"
+              ],
+              "description": "Type of log records:\n\n1 - #WTL text line\n\n2 - User trace text or physical I/O trace text\n\n3 - User binary trace entries\n\n4 - Snap or dump text\n\n5 - Snap or dump binary entries\n\nExamples: '1,2', '1,4,5', '2'",
+              "type": "string",
+              "group": "Options"
+            },
+            {
+              "name": "record-identifier",
+              "aliases": [
+                "ri"
+              ],
+              "description": "Identifier contained in log messages\n\nExamples: 'LTE0001,LTVTM011', 'DCSYSTEM', 'SYSTE160'",
+              "type": "string",
+              "group": "Options"
+            },
+            {
+              "name": "search-text",
+              "aliases": [
+                "stext"
+              ],
+              "description": "Text contained in log messages\n\nExamples: 'DB001108', 'any_text_that_might_exist_in_the_message'",
+              "type": "string",
+              "group": "Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--start-time \"2020-08-05 09:20:00\" --end-time \"2020-08-05 10:20:00\"",
+              "description": "Lists all the log messages where the time stamps satisfy the start and end time criteria"
+            },
+            {
+              "options": "--start-time \"2020-08-05 09:20:00\" --end-time \"2020-08-05 10:20:00\" --record-type 1 --search-text DB001108",
+              "description": "Lists all the #WTL log messages where 'DB001108' is contained in the log message and where the time stamps satisfy the start and end time criteria"
+            },
+            {
+              "options": "--start-time \"2020-08-05 08:00:00.001234\" --end-time \"2020-08-05 13:43:33.26\" --record-identifier DCSYSTEM",
+              "description": "Lists all log messages with the DCSYSTEM record identifier where the time stamps satisfy the start and end time criteria"
+            }
+          ],
+          "aliases": [],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "transactions",
+          "aliases": [
+            "ts"
+          ],
+          "summary": "Lists details of active IDMS transactions",
+          "description": "Lists transaction details on a specific IDMS system",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "jobname",
+              "aliases": [
+                "j"
+              ],
+              "description": "The job name of the active IDMS system",
+              "type": "string",
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "datasourcename",
+              "aliases": [
+                "dsn"
+              ],
+              "description": "The data source name of the specified IDMS system",
+              "type": "string",
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--jobname SYSDEMO",
+              "description": "Lists the transaction details of the IDMS system identified by the IDMS system job name"
+            },
+            {
+              "options": "--jobname SYSDEMO --rfj",
+              "description": "Lists the transaction details of the IDMS system identified by the IDMS system job name as JSON formatted data"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        },
+        {
+          "name": "user-tasks",
+          "aliases": [
+            "ut"
+          ],
+          "summary": "Lists active IDMS user tasks",
+          "description": "Lists all active user tasks on a specific IDMS system",
+          "type": "command",
+          "handler": "",
+          "options": [
+            {
+              "name": "host",
+              "aliases": [
+                "H"
+              ],
+              "description": "Host name of the IDMS REST API service",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "port",
+              "aliases": [
+                "P"
+              ],
+              "description": "Port for the IDMS REST API service",
+              "type": "number",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "user",
+              "aliases": [
+                "u"
+              ],
+              "description": "Mainframe user name, which can be the same as your TSO login ID",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "password",
+              "aliases": [
+                "pass",
+                "pw"
+              ],
+              "description": "Mainframe password, which can be the same as your TSO password",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "reject-unauthorized",
+              "aliases": [
+                "ru"
+              ],
+              "description": "Reject self-signed certificates",
+              "type": "boolean",
+              "defaultValue": true,
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "base-path",
+              "aliases": [
+                "bp"
+              ],
+              "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "datasource",
+              "aliases": [
+                "d"
+              ],
+              "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+              "type": "string",
+              "group": "IDMS Connection Options"
+            },
+            {
+              "name": "jobname",
+              "aliases": [
+                "j"
+              ],
+              "description": "The job name of the active IDMS system",
+              "type": "string",
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "datasourcename",
+              "aliases": [
+                "dsn"
+              ],
+              "description": "The data source name of the specified IDMS system",
+              "type": "string",
+              "required": true,
+              "group": "Required Options"
+            },
+            {
+              "name": "show-inputs-only",
+              "group": "Global Options",
+              "description": "Show command inputs and do not run the command",
+              "type": "boolean",
+              "aliases": []
+            },
+            {
+              "name": "response-format-json",
+              "aliases": [
+                "rfj"
+              ],
+              "group": "Global Options",
+              "description": "Produce JSON formatted data from a command",
+              "type": "boolean"
+            },
+            {
+              "name": "help",
+              "aliases": [
+                "h"
+              ],
+              "group": "Global Options",
+              "description": "Display help text",
+              "type": "boolean"
+            },
+            {
+              "name": "help-web",
+              "aliases": [
+                "hw"
+              ],
+              "group": "Global Options",
+              "description": "Display HTML help in browser",
+              "type": "boolean"
+            },
+            {
+              "name": "idms-profile",
+              "aliases": [
+                "idms-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (idms) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "base-profile",
+              "aliases": [
+                "base-p"
+              ],
+              "group": "Profile Options",
+              "description": "The name of a (base) profile to load for this command execution.",
+              "type": "string"
+            },
+            {
+              "name": "token-type",
+              "aliases": [
+                "tt"
+              ],
+              "description": "The type of token to get and use for the API. Omit this option to use the default token type, which is provided by 'zowe auth login'.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "token-value",
+              "aliases": [
+                "tv"
+              ],
+              "description": "The value of the token to pass to the API.",
+              "type": "string",
+              "group": "Base Connection Options"
+            },
+            {
+              "name": "cert-file",
+              "description": "The file path to a certificate file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "cert-key-file",
+              "description": "The file path to a certificate key file to use for authentication",
+              "type": "existingLocalFile",
+              "group": "Base Connection Options",
+              "aliases": []
+            },
+            {
+              "name": "response-format-filter",
+              "aliases": [
+                "rff"
+              ],
+              "description": "Filter (include) fields in the response. Accepts an array of field/property names to include in the output response. You can filter JSON objects properties OR table columns/fields. In addition, you can use this option in conjunction with '--response-format-type' to reduce the output of a command to a single field/property or a list of a single field/property.",
+              "type": "array",
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-type",
+              "aliases": [
+                "rft"
+              ],
+              "description": "The command response output format type. Must be one of the following:\n\ntable: Formats output data as a table. Use this option when the output data is an array of homogeneous JSON objects. Each property of the object will become a column in the table.\n\nlist: Formats output data as a list of strings. Can be used on any data type (JSON objects/arrays) are stringified and a new line is added after each entry in an array.\n\nobject: Formats output data as a list of prettified objects (or single object). Can be used in place of \"table\" to change from tabular output to a list of prettified objects.\n\nstring: Formats output data as a string. JSON objects/arrays are stringified.",
+              "type": "string",
+              "allowableValues": {
+                "values": [
+                  "table",
+                  "list",
+                  "object",
+                  "string"
+                ],
+                "caseSensitive": false
+              },
+              "group": "Response Format Options"
+            },
+            {
+              "name": "response-format-header",
+              "aliases": [
+                "rfh"
+              ],
+              "description": "If \"--response-format-type table\" is specified, include the column headers in the output.",
+              "type": "boolean",
+              "group": "Response Format Options",
+              "defaultValue": null
+            }
+          ],
+          "profile": {
+            "optional": [
+              "idms",
+              "base"
+            ]
+          },
+          "outputFormatOptions": true,
+          "examples": [
+            {
+              "options": "--jobname SYSDEMO",
+              "description": "Lists the active user tasks of the IDMS system identified by the IDMS system job name"
+            },
+            {
+              "options": "--jobname SYSDEMO --rfj",
+              "description": "Lists the active user tasks of the IDMS system identified by the IDMS system job name as JSON formatted data"
+            }
+          ],
+          "positionals": [],
+          "passOn": [],
+          "children": []
+        }
+      ],
+      "passOn": [
+        {
+          "property": "options",
+          "value": [
+            {
+              "name": "jobname",
+              "aliases": [
+                "j"
+              ],
+              "description": "The job name of the active IDMS system",
+              "type": "string",
+              "required": true
+            },
+            {
+              "name": "datasourcename",
+              "aliases": [
+                "dsn"
+              ],
+              "description": "The data source name of the specified IDMS system",
+              "type": "string",
+              "required": true
+            }
+          ],
+          "merge": true,
+          "ignoreNodes": [
+            {
+              "type": "group"
+            },
+            {
+              "name": "datasources"
+            },
+            {
+              "name": "systems"
+            },
+            {
+              "name": "log"
+            }
+          ]
+        }
+      ],
+      "options": [
+        {
+          "name": "help-examples",
+          "group": "Global Options",
+          "description": "Display examples for all the commands in a group",
+          "type": "boolean",
+          "aliases": []
+        },
+        {
+          "name": "response-format-json",
+          "aliases": [
+            "rfj"
+          ],
+          "group": "Global Options",
+          "description": "Produce JSON formatted data from a command",
+          "type": "boolean"
+        },
+        {
+          "name": "help",
+          "aliases": [
+            "h"
+          ],
+          "group": "Global Options",
+          "description": "Display help text",
+          "type": "boolean"
+        },
+        {
+          "name": "help-web",
+          "aliases": [
+            "hw"
+          ],
+          "group": "Global Options",
+          "description": "Display HTML help in browser",
+          "type": "boolean"
+        }
+      ],
+      "positionals": []
+    }
+  ],
+  "summary": "Interact with IDMS",
+  "options": [
+    {
+      "name": "help-examples",
+      "group": "Global Options",
+      "description": "Display examples for all the commands in a group",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global Options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global Options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global Options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "aliases": [],
+  "positionals": [],
+  "passOn": []
+}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     },
     "dependencies": {
         "@types/node": "^16.11.1",
-        "@zowe/cli": "^7.9.0",
-        "@zowe/imperative": "^5.7.2",
+        "@zowe/cli": "^7.11.0",
+        "@zowe/imperative": "^5.9.0",
         "husky": "^7.0.2",
         "jsonc": "^2.0.0",
         "ts-node": "^10.3.0",

--- a/profiles/create/dbm-db2.jsonc
+++ b/profiles/create/dbm-db2.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "dbm-db2-profile",
@@ -197,7 +197,7 @@
     },
     {
       "name": "show-inputs-only",
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Show command inputs and do not run the command",
       "type": "boolean",
       "aliases": []
@@ -207,7 +207,7 @@
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -216,23 +216,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/profiles/create/ebg.jsonc
+++ b/profiles/create/ebg.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "ebg-profile",
@@ -109,7 +109,7 @@
     },
     {
       "name": "show-inputs-only",
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Show command inputs and do not run the command",
       "type": "boolean",
       "aliases": []
@@ -119,7 +119,7 @@
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -128,23 +128,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/profiles/create/idms.jsonc
+++ b/profiles/create/idms.jsonc
@@ -1,0 +1,155 @@
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "idms-profile",
+  "aliases": [
+    "idms"
+  ],
+  "summary": "Create a idms profile",
+  "description": "An IDMS profile is required to issue IDMS CLI commands. The IDMS profile contains your host and port information",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config init' command",
+  "customize": {
+    "profileTypeIdentifier": "idms"
+  },
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the new idms profile. You can load this profile by using the name on commands that support the \"--idms-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "options": [
+    {
+      "name": "host",
+      "aliases": [
+        "H"
+      ],
+      "description": "Host name of the IDMS REST API service",
+      "type": "string",
+      "group": "IDMS Connection Options"
+    },
+    {
+      "name": "port",
+      "aliases": [
+        "P"
+      ],
+      "description": "Port for the IDMS REST API service",
+      "type": "number",
+      "group": "IDMS Connection Options"
+    },
+    {
+      "name": "user",
+      "aliases": [
+        "u"
+      ],
+      "description": "Mainframe user name, which can be the same as your TSO login ID",
+      "type": "string",
+      "group": "IDMS Connection Options"
+    },
+    {
+      "name": "password",
+      "aliases": [
+        "pass",
+        "pw"
+      ],
+      "description": "Mainframe password, which can be the same as your TSO password",
+      "type": "string",
+      "group": "IDMS Connection Options"
+    },
+    {
+      "name": "datasource",
+      "aliases": [
+        "d"
+      ],
+      "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+      "type": "string",
+      "group": "IDMS Connection Options"
+    },
+    {
+      "name": "base-path",
+      "aliases": [
+        "bp"
+      ],
+      "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+      "type": "string",
+      "group": "IDMS Connection Options"
+    },
+    {
+      "name": "reject-unauthorized",
+      "aliases": [
+        "ru"
+      ],
+      "description": "Reject self-signed certificates",
+      "type": "boolean",
+      "defaultValue": true,
+      "group": "IDMS Connection Options"
+    },
+    {
+      "name": "overwrite",
+      "aliases": [
+        "ow"
+      ],
+      "description": "Overwrite the idms profile when a profile of the same name exists.",
+      "type": "boolean",
+      "group": "Options"
+    },
+    {
+      "name": "disable-defaults",
+      "aliases": [
+        "dd"
+      ],
+      "description": "Disable populating profile values of undefined properties with default values.",
+      "type": "boolean",
+      "group": "Options"
+    },
+    {
+      "name": "show-inputs-only",
+      "group": "Global Options",
+      "description": "Show command inputs and do not run the command",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global Options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global Options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global Options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "examples": [
+    {
+      "options": "idms11 --host zos123 --port 1234 --user myuid --password mypass  --base-path api/v1/caidms --reject-unauthorized false",
+      "description": "Create an IDMS profile called 'idms11' to connect to IDMS API services at host zos123 and port 1234, with base path api/v1/caidms and allow self-signed certificates"
+    },
+    {
+      "options": "idms99 --host zos123 --port 1234 --user myuid --password mypass  --datasource SYS195 --reject-unauthorized false",
+      "description": "Create an IDMS profile called 'idms99' to connect to IDMS API services at host zos123 and port 1234, specify a default data source SYS195 to be used by JDBC to identify a target system and allow self-signed certificates"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}

--- a/profiles/delete/dbm-db2.jsonc
+++ b/profiles/delete/dbm-db2.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "dbm-db2-profile",
@@ -24,7 +24,7 @@
     },
     {
       "name": "show-inputs-only",
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Show command inputs and do not run the command",
       "type": "boolean",
       "aliases": []
@@ -34,7 +34,7 @@
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -43,23 +43,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/profiles/delete/ebg.jsonc
+++ b/profiles/delete/ebg.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "ebg-profile",
@@ -24,7 +24,7 @@
     },
     {
       "name": "show-inputs-only",
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Show command inputs and do not run the command",
       "type": "boolean",
       "aliases": []
@@ -34,7 +34,7 @@
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -43,23 +43,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/profiles/delete/idms.jsonc
+++ b/profiles/delete/idms.jsonc
@@ -1,16 +1,27 @@
 // Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
-  "name": "ebg-profile",
+  "name": "idms-profile",
   "aliases": [
-    "ebg"
+    "idms"
   ],
-  "summary": "Set the default\n profiles for the ebg group",
-  "description": "The ebg set default-profiles command allows you to set the default profiles for this command group. When a ebg command is issued and no profile override options are specified, the default profiles for the command group are automatically loaded for the command based on the commands profile requirements.",
+  "summary": "Delete a idms profile.",
+  "description": "Delete a idms profile. You must specify a profile name to be deleted. To find a list of available profiles for deletion, issue the profiles list command. By default, you will be prompted to confirm the profile removal.",
   "type": "command",
   "handler": "",
-  "deprecatedReplacement": "The 'config set' command",
+  "deprecatedReplacement": "Edit your Zowe V2 configuration\n    zowe.config.json",
+  "customize": {
+    "profileTypeIdentifier": "idms"
+  },
   "options": [
+    {
+      "name": "force",
+      "aliases": [],
+      "description": "Force deletion of profile, and dependent profiles if specified. No prompt will be displayed before  deletion occurs.",
+      "type": "boolean",
+      "required": false,
+      "group": "Options"
+    },
     {
       "name": "show-inputs-only",
       "group": "Global Options",
@@ -49,18 +60,15 @@
   "positionals": [
     {
       "name": "profileName",
-      "description": "Specify a\n profile for default usage within the ebg group. When you issue commands within the ebg group without a profile specified as part of the command, the default will be loaded instead.",
+      "description": "Specifies the name of the idms  profile to be deleted. You can also load this profile by using the name on commands that support the \"--idms-profile\" option.",
       "type": "string",
       "required": true
     }
   ],
-  "customize": {
-    "profileTypeIdentifier": "ebg"
-  },
   "examples": [
     {
       "options": "profilename",
-      "description": "Set the default profile for type ebg to the profile named 'profilename'"
+      "description": "Delete a idms profile named profilename"
     }
   ],
   "passOn": [],

--- a/profiles/list/dbm-db2.jsonc
+++ b/profiles/list/dbm-db2.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "dbm-db2-profiles",
@@ -26,7 +26,7 @@
     },
     {
       "name": "show-inputs-only",
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Show command inputs and do not run the command",
       "type": "boolean",
       "aliases": []
@@ -36,7 +36,7 @@
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -45,23 +45,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/profiles/list/ebg.jsonc
+++ b/profiles/list/ebg.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "ebg-profiles",
@@ -26,7 +26,7 @@
     },
     {
       "name": "show-inputs-only",
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Show command inputs and do not run the command",
       "type": "boolean",
       "aliases": []
@@ -36,7 +36,7 @@
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -45,23 +45,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/profiles/list/idms.jsonc
+++ b/profiles/list/idms.jsonc
@@ -1,16 +1,29 @@
 // Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
-  "name": "ebg-profile",
+  "name": "idms-profiles",
   "aliases": [
-    "ebg"
+    "idms"
   ],
-  "summary": "Set the default\n profiles for the ebg group",
-  "description": "The ebg set default-profiles command allows you to set the default profiles for this command group. When a ebg command is issued and no profile override options are specified, the default profiles for the command group are automatically loaded for the command based on the commands profile requirements.",
+  "summary": "List profiles of the type idms.",
+  "description": "An IDMS profile is required to issue IDMS CLI commands. The IDMS profile contains your host and port information",
   "type": "command",
   "handler": "",
-  "deprecatedReplacement": "The 'config set' command",
+  "deprecatedReplacement": "The 'config list' command",
+  "customize": {
+    "profileTypeIdentifier": "idms"
+  },
   "options": [
+    {
+      "name": "show-contents",
+      "aliases": [
+        "sc"
+      ],
+      "description": "List idms  profiles  and their contents. All profile details will be printed as part of command output.",
+      "type": "boolean",
+      "required": false,
+      "group": "Options"
+    },
     {
       "name": "show-inputs-only",
       "group": "Global Options",
@@ -46,23 +59,17 @@
       "type": "boolean"
     }
   ],
-  "positionals": [
-    {
-      "name": "profileName",
-      "description": "Specify a\n profile for default usage within the ebg group. When you issue commands within the ebg group without a profile specified as part of the command, the default will be loaded instead.",
-      "type": "string",
-      "required": true
-    }
-  ],
-  "customize": {
-    "profileTypeIdentifier": "ebg"
-  },
   "examples": [
     {
-      "options": "profilename",
-      "description": "Set the default profile for type ebg to the profile named 'profilename'"
+      "options": "",
+      "description": "List profiles of type idms"
+    },
+    {
+      "options": "--sc",
+      "description": "List profiles of type idms and display their contents"
     }
   ],
+  "positionals": [],
   "passOn": [],
   "children": []
 }

--- a/profiles/set-default/dbm-db2.jsonc
+++ b/profiles/set-default/dbm-db2.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "dbm-db2-profile",
@@ -13,7 +13,7 @@
   "options": [
     {
       "name": "show-inputs-only",
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Show command inputs and do not run the command",
       "type": "boolean",
       "aliases": []
@@ -23,7 +23,7 @@
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -32,23 +32,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/profiles/set-default/idms.jsonc
+++ b/profiles/set-default/idms.jsonc
@@ -1,12 +1,12 @@
 // Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
-  "name": "ebg-profile",
+  "name": "idms-profile",
   "aliases": [
-    "ebg"
+    "idms"
   ],
-  "summary": "Set the default\n profiles for the ebg group",
-  "description": "The ebg set default-profiles command allows you to set the default profiles for this command group. When a ebg command is issued and no profile override options are specified, the default profiles for the command group are automatically loaded for the command based on the commands profile requirements.",
+  "summary": "Set the default\n profiles for the idms group",
+  "description": "The idms set default-profiles command allows you to set the default profiles for this command group. When a idms command is issued and no profile override options are specified, the default profiles for the command group are automatically loaded for the command based on the commands profile requirements.",
   "type": "command",
   "handler": "",
   "deprecatedReplacement": "The 'config set' command",
@@ -49,18 +49,18 @@
   "positionals": [
     {
       "name": "profileName",
-      "description": "Specify a\n profile for default usage within the ebg group. When you issue commands within the ebg group without a profile specified as part of the command, the default will be loaded instead.",
+      "description": "Specify a\n profile for default usage within the idms group. When you issue commands within the idms group without a profile specified as part of the command, the default will be loaded instead.",
       "type": "string",
       "required": true
     }
   ],
   "customize": {
-    "profileTypeIdentifier": "ebg"
+    "profileTypeIdentifier": "idms"
   },
   "examples": [
     {
       "options": "profilename",
-      "description": "Set the default profile for type ebg to the profile named 'profilename'"
+      "description": "Set the default profile for type idms to the profile named 'profilename'"
     }
   ],
   "passOn": [],

--- a/profiles/update/dbm-db2.jsonc
+++ b/profiles/update/dbm-db2.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "dbm-db2-profile",
@@ -189,7 +189,7 @@
     },
     {
       "name": "show-inputs-only",
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Show command inputs and do not run the command",
       "type": "boolean",
       "aliases": []
@@ -199,7 +199,7 @@
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -208,23 +208,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/profiles/update/ebg.jsonc
+++ b/profiles/update/ebg.jsonc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Broadcom.  All Rights Reserved.  The term
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
 // "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 {
   "name": "ebg-profile",
@@ -103,7 +103,7 @@
     },
     {
       "name": "show-inputs-only",
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Show command inputs and do not run the command",
       "type": "boolean",
       "aliases": []
@@ -113,7 +113,7 @@
       "aliases": [
         "rfj"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Produce JSON formatted data from a command",
       "type": "boolean"
     },
@@ -122,23 +122,16 @@
       "aliases": [
         "h"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display help text",
       "type": "boolean"
-    },
-    {
-      "name": "help-examples",
-      "group": "Global options",
-      "description": "Display examples for all the commands in a group",
-      "type": "boolean",
-      "aliases": []
     },
     {
       "name": "help-web",
       "aliases": [
         "hw"
       ],
-      "group": "Global options",
+      "group": "Global Options",
       "description": "Display HTML help in browser",
       "type": "boolean"
     }

--- a/profiles/update/idms.jsonc
+++ b/profiles/update/idms.jsonc
@@ -1,0 +1,153 @@
+// Copyright (c) 2023 Broadcom.  All Rights Reserved.  The term
+// "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+{
+  "name": "idms-profile",
+  "aliases": [
+    "idms"
+  ],
+  "summary": "Update a idms profile. You can update any property present within the profile configuration. The updated profile will be printed so that you can review the result of the updates.",
+  "description": "An IDMS profile is required to issue IDMS CLI commands. The IDMS profile contains your host and port information",
+  "type": "command",
+  "handler": "",
+  "deprecatedReplacement": "The 'config set' command",
+  "customize": {
+    "profileTypeIdentifier": "idms"
+  },
+  "positionals": [
+    {
+      "name": "profileName",
+      "description": "Specifies the name of the new idms profile. You can load this profile by using the name on commands that support the \"--idms-profile\" option.",
+      "type": "string",
+      "required": true
+    }
+  ],
+  "options": [
+    {
+      "name": "host",
+      "aliases": [
+        "H"
+      ],
+      "description": "Host name of the IDMS REST API service",
+      "type": "string",
+      "group": "IDMS Connection Options",
+      "required": false,
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "port",
+      "aliases": [
+        "P"
+      ],
+      "description": "Port for the IDMS REST API service",
+      "type": "number",
+      "group": "IDMS Connection Options",
+      "required": false,
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "user",
+      "aliases": [
+        "u"
+      ],
+      "description": "Mainframe user name, which can be the same as your TSO login ID",
+      "type": "string",
+      "group": "IDMS Connection Options",
+      "required": false,
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "password",
+      "aliases": [
+        "pass",
+        "pw"
+      ],
+      "description": "Mainframe password, which can be the same as your TSO password",
+      "type": "string",
+      "group": "IDMS Connection Options",
+      "required": false,
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "datasource",
+      "aliases": [
+        "d"
+      ],
+      "description": "Identifies the IDMS system where the API request will be sent and is defined in the data sources definition file for the IDMS REST API",
+      "type": "string",
+      "group": "IDMS Connection Options",
+      "required": false,
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "base-path",
+      "aliases": [
+        "bp"
+      ],
+      "description": "The base path for your API Mediation Layer instance. Specify this option to prepend the base path to all resources when making REST requests. Only specify this option if you are using an API Mediation Layer",
+      "type": "string",
+      "group": "IDMS Connection Options",
+      "required": false,
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "reject-unauthorized",
+      "aliases": [
+        "ru"
+      ],
+      "description": "Reject self-signed certificates",
+      "type": "boolean",
+      "group": "IDMS Connection Options",
+      "required": false,
+      "absenceImplications": null,
+      "implies": null
+    },
+    {
+      "name": "show-inputs-only",
+      "group": "Global Options",
+      "description": "Show command inputs and do not run the command",
+      "type": "boolean",
+      "aliases": []
+    },
+    {
+      "name": "response-format-json",
+      "aliases": [
+        "rfj"
+      ],
+      "group": "Global Options",
+      "description": "Produce JSON formatted data from a command",
+      "type": "boolean"
+    },
+    {
+      "name": "help",
+      "aliases": [
+        "h"
+      ],
+      "group": "Global Options",
+      "description": "Display help text",
+      "type": "boolean"
+    },
+    {
+      "name": "help-web",
+      "aliases": [
+        "hw"
+      ],
+      "group": "Global Options",
+      "description": "Display HTML help in browser",
+      "type": "boolean"
+    }
+  ],
+  "examples": [
+    {
+      "options": "idms99 --datasource SYS100",
+      "description": "Update an IDMS profile called 'idms99' with a new default data source SYS100"
+    }
+  ],
+  "passOn": [],
+  "children": []
+}


### PR DESCRIPTION
Adds the IDMS for Zowe CLI plug-in help 
Updates the Endevor Bridge for Git for Zowe CLI plug-in help
Updates the Database Management for Db2 for Zowe CLI plug-in help

Updates the CLI and Imperative dependencies for the repository

Updates the GitHub workflows to use newer versions of actions
Updates the GitHub workflows to use replacements for deprecated actions
