### PR TITLE
Use GH CLI to run workflows instead

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -2,38 +2,25 @@ name: Cron Workflows
 on:
   schedule:
   - cron: '0 0 * * *'
+env:
+  GITHUB_TOKEN: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
 jobs:
   v1-lts:
     runs-on: ubuntu-latest
     steps:
       - name: Test Scripts
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: Test Scripts
-          token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
-          ref: zowe-v1-lts
+        run: gh workflow run -r zowe-v1-lts test.yml
+          
       - name: WebHelp CI
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: CI for WebHelp Contribution
-          token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
-          inputs: '{ "release": "false" }'
-          ref: zowe-v1-lts
+        run: gh workflow run -r zowe-v1-lts -f release=false main.yml
+
   v2-lts:
     runs-on: ubuntu-latest
     steps:
       - name: Test Scripts
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: Test Scripts
-          token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
-          ref: master
+        run: gh workflow run -r master test.yml
+
       - name: WebHelp CI
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: CI for WebHelp Contribution
-          token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
-          inputs: '{ "release": "false" }'
-          ref: master
+        run: gh workflow run -r master -f release=false main.yml
         


### PR DESCRIPTION
Updates the repository to use workflow dispatch via GitHub CLI